### PR TITLE
feat: implement Worker.run() with concurrency and graceful shutdown (S007)

### DIFF
--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -1,5 +1,6 @@
 """Unit tests for Worker receive functionality."""
 
+import asyncio
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -641,3 +642,227 @@ class TestWorkerComplete:
 
             call_kwargs = mock_audit.call_args[1]
             assert call_kwargs["details"]["has_result"] is True
+
+
+class TestWorkerRun:
+    """Tests for Worker.run() and related methods."""
+
+    @pytest.fixture
+    def mock_pool(self) -> MagicMock:
+        """Create a mock connection pool with transaction support."""
+        pool = MagicMock()
+        conn = MagicMock()
+        transaction = MagicMock()
+
+        @asynccontextmanager
+        async def mock_connection():
+            yield conn
+
+        @asynccontextmanager
+        async def mock_transaction():
+            yield transaction
+
+        pool.connection = mock_connection
+        conn.transaction = mock_transaction
+        return pool
+
+    @pytest.fixture
+    def mock_registry(self) -> MagicMock:
+        """Create a mock handler registry."""
+        registry = MagicMock()
+        registry.dispatch = AsyncMock(return_value={"processed": True})
+        return registry
+
+    @pytest.fixture
+    def worker(self, mock_pool: MagicMock, mock_registry: MagicMock) -> Worker:
+        """Create a worker with mocked pool and registry."""
+        return Worker(mock_pool, domain="payments", registry=mock_registry)
+
+    def test_worker_init_with_registry(self, worker: Worker) -> None:
+        """Test worker initialization with registry."""
+        assert worker._registry is not None
+        assert worker._running is False
+        assert worker._stop_event is None
+        assert len(worker._in_flight) == 0
+
+    def test_is_running_property(self, worker: Worker) -> None:
+        """Test is_running property."""
+        assert worker.is_running is False
+        worker._running = True
+        assert worker.is_running is True
+
+    def test_in_flight_count_property(self, worker: Worker) -> None:
+        """Test in_flight_count property."""
+        assert worker.in_flight_count == 0
+
+    @pytest.mark.asyncio
+    async def test_run_without_registry_raises_error(self, mock_pool: MagicMock) -> None:
+        """Test that run raises error without registry."""
+        worker = Worker(mock_pool, domain="payments")
+        with pytest.raises(RuntimeError, match="Cannot run worker without a handler registry"):
+            await worker.run()
+
+    @pytest.mark.asyncio
+    async def test_run_sets_running_flag(self, worker: Worker) -> None:
+        """Test that run sets the running flag."""
+        with patch.object(worker, "_run_with_polling", new_callable=AsyncMock) as mock_run:
+
+            async def stop_after_start(*args: object, **kwargs: object) -> None:
+                await asyncio.sleep(0.01)
+                await worker.stop()
+
+            mock_run.side_effect = stop_after_start
+
+            await worker.run(use_notify=False)
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_event(self, worker: Worker) -> None:
+        """Test that stop sets the stop event."""
+        worker._running = True
+        worker._stop_event = asyncio.Event()
+
+        await worker.stop()
+
+        assert worker._stop_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_stop_when_not_running(self, worker: Worker) -> None:
+        """Test that stop does nothing when not running."""
+        await worker.stop()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_process_batch_receives_commands(self, worker: Worker) -> None:
+        """Test that _process_batch receives and processes commands."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+
+        received = ReceivedCommand(
+            command=Command(
+                domain="payments",
+                command_type="DebitAccount",
+                command_id=command_id,
+                data={},
+                created_at=now,
+            ),
+            context=HandlerContext(
+                command=MagicMock(),
+                attempt=1,
+                max_attempts=3,
+                msg_id=42,
+            ),
+            msg_id=42,
+            metadata=MagicMock(),
+        )
+
+        semaphore = asyncio.Semaphore(5)
+
+        with (
+            patch.object(worker, "receive", new_callable=AsyncMock) as mock_receive,
+            patch.object(worker, "_process_command", new_callable=AsyncMock),
+        ):
+            mock_receive.return_value = [received]
+
+            await worker._process_batch(semaphore)
+
+            mock_receive.assert_called_once_with(batch_size=5)
+
+    @pytest.mark.asyncio
+    async def test_process_batch_skips_when_no_slots(self, worker: Worker) -> None:
+        """Test that _process_batch skips when no slots available."""
+        semaphore = asyncio.Semaphore(0)
+
+        with patch.object(worker, "receive", new_callable=AsyncMock) as mock_receive:
+            await worker._process_batch(semaphore)
+
+            mock_receive.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_command_dispatches_and_completes(self, worker: Worker) -> None:
+        """Test that _process_command dispatches and completes."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+
+        received = ReceivedCommand(
+            command=Command(
+                domain="payments",
+                command_type="DebitAccount",
+                command_id=command_id,
+                data={},
+                created_at=now,
+            ),
+            context=HandlerContext(
+                command=MagicMock(),
+                attempt=1,
+                max_attempts=3,
+                msg_id=42,
+            ),
+            msg_id=42,
+            metadata=MagicMock(),
+        )
+
+        semaphore = asyncio.Semaphore(1)
+
+        with patch.object(worker, "complete", new_callable=AsyncMock) as mock_complete:
+            await worker._process_command(received, semaphore)
+
+            mock_complete.assert_called_once()
+            call_kwargs = mock_complete.call_args[1]
+            assert call_kwargs["result"] == {"processed": True}
+
+    @pytest.mark.asyncio
+    async def test_process_command_handles_errors(
+        self, worker: Worker, mock_registry: MagicMock
+    ) -> None:
+        """Test that _process_command handles handler errors gracefully."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+
+        received = ReceivedCommand(
+            command=Command(
+                domain="payments",
+                command_type="DebitAccount",
+                command_id=command_id,
+                data={},
+                created_at=now,
+            ),
+            context=HandlerContext(
+                command=MagicMock(),
+                attempt=1,
+                max_attempts=3,
+                msg_id=42,
+            ),
+            msg_id=42,
+            metadata=MagicMock(),
+        )
+
+        semaphore = asyncio.Semaphore(1)
+        mock_registry.dispatch.side_effect = Exception("Handler failed")
+
+        with patch.object(worker, "complete", new_callable=AsyncMock) as mock_complete:
+            # Should not raise
+            await worker._process_command(received, semaphore)
+
+            # Complete should not be called on error
+            mock_complete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_wait_for_in_flight(self, worker: Worker) -> None:
+        """Test _wait_for_in_flight waits for tasks."""
+        task1_done = asyncio.Event()
+        task2_done = asyncio.Event()
+
+        async def slow_task1() -> None:
+            await asyncio.sleep(0.01)
+            task1_done.set()
+
+        async def slow_task2() -> None:
+            await asyncio.sleep(0.01)
+            task2_done.set()
+
+        worker._in_flight.add(asyncio.create_task(slow_task1()))
+        worker._in_flight.add(asyncio.create_task(slow_task2()))
+
+        await worker._wait_for_in_flight()
+
+        assert task1_done.is_set()
+        assert task2_done.is_set()


### PR DESCRIPTION
## Summary
- Implement `Worker.run()` method with configurable concurrency
- Add graceful shutdown via `stop()` method that waits for in-flight commands
- Support pg_notify LISTEN for immediate wake-up when commands arrive
- Fall back to polling at configurable interval when notify misses
- Add `is_running` and `in_flight_count` properties for monitoring

Closes #12

## Test plan
- [x] Unit tests verify:
  - Worker initialization with registry
  - is_running and in_flight_count properties
  - run() raises error without registry
  - stop() sets event and waits for in-flight
  - _process_batch receives and processes commands
  - _process_command dispatches and completes
  - Handler errors are handled gracefully
- [x] Integration tests verify:
  - Worker processes commands with handlers
  - Concurrent processing of multiple commands
  - Graceful shutdown waits for in-flight commands
  - Poll fallback mechanism works

🤖 Generated with [Claude Code](https://claude.com/claude-code)