### PR TITLE
feat(worker): add automatic retry on transient failure

### DIFF
--- a/src/commandbus/__init__.py
+++ b/src/commandbus/__init__.py
@@ -18,11 +18,13 @@ from commandbus.models import (
     ReplyOutcome,
 )
 from commandbus.pgmq.client import PgmqClient, PgmqMessage
+from commandbus.policies import DEFAULT_RETRY_POLICY, RetryPolicy
 from commandbus.repositories.audit import AuditEventType, PostgresAuditLogger
 from commandbus.repositories.command import PostgresCommandRepository
 from commandbus.worker import ReceivedCommand, Worker
 
 __all__ = [
+    "DEFAULT_RETRY_POLICY",
     "AuditEventType",
     "Command",
     "CommandBus",
@@ -41,6 +43,7 @@ __all__ = [
     "PostgresCommandRepository",
     "ReceivedCommand",
     "ReplyOutcome",
+    "RetryPolicy",
     "SendResult",
     "TransientCommandError",
     "Worker",

--- a/src/commandbus/policies.py
+++ b/src/commandbus/policies.py
@@ -1,0 +1,66 @@
+"""Retry policies for command processing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class RetryPolicy:
+    """Policy for handling command retries.
+
+    Attributes:
+        max_attempts: Maximum number of attempts before giving up
+        backoff_schedule: List of visibility timeouts in seconds for each retry.
+                         Index 0 is used for attempt 2, index 1 for attempt 3, etc.
+                         If attempts exceed the schedule length, the last value is used.
+
+    Example:
+        policy = RetryPolicy(max_attempts=4, backoff_schedule=[10, 60, 300])
+        # Attempt 1: immediate (initial processing)
+        # Attempt 2: 10 seconds delay
+        # Attempt 3: 60 seconds delay
+        # Attempt 4: 300 seconds delay
+    """
+
+    max_attempts: int = 3
+    backoff_schedule: list[int] = field(default_factory=lambda: [10, 60, 300])
+
+    def get_backoff(self, attempt: int) -> int:
+        """Get the backoff delay for a given attempt number.
+
+        Args:
+            attempt: The current attempt number (1-based)
+
+        Returns:
+            Visibility timeout in seconds for the next retry.
+            Returns 0 if no more retries should occur.
+        """
+        if attempt >= self.max_attempts:
+            return 0  # No more retries
+
+        # Attempt 1 -> index 0, attempt 2 -> index 1, etc.
+        index = attempt - 1
+        if index < 0:
+            return self.backoff_schedule[0] if self.backoff_schedule else 30
+
+        if index < len(self.backoff_schedule):
+            return self.backoff_schedule[index]
+
+        # Use last value for attempts beyond schedule length
+        return self.backoff_schedule[-1] if self.backoff_schedule else 30
+
+    def should_retry(self, attempt: int) -> bool:
+        """Check if another retry should be attempted.
+
+        Args:
+            attempt: The current attempt number (1-based)
+
+        Returns:
+            True if more attempts are allowed
+        """
+        return attempt < self.max_attempts
+
+
+# Default retry policy used by workers
+DEFAULT_RETRY_POLICY = RetryPolicy()

--- a/tests/integration/test_retry.py
+++ b/tests/integration/test_retry.py
@@ -1,0 +1,335 @@
+"""Integration tests for transient retry flow."""
+
+import asyncio
+import contextlib
+from uuid import uuid4
+
+import pytest
+from psycopg_pool import AsyncConnectionPool
+
+from commandbus import (
+    Command,
+    CommandBus,
+    CommandStatus,
+    HandlerContext,
+    HandlerRegistry,
+    PostgresAuditLogger,
+    PostgresCommandRepository,
+    RetryPolicy,
+    TransientCommandError,
+    Worker,
+)
+from commandbus.repositories.audit import AuditEventType
+
+
+@pytest.fixture
+def handler_registry() -> HandlerRegistry:
+    """Create handler registry."""
+    return HandlerRegistry()
+
+
+class TestTransientRetryFlow:
+    """Integration tests for transient error retry flow."""
+
+    @pytest.mark.asyncio
+    async def test_transient_error_updates_metadata(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+    ) -> None:
+        """Test that transient error updates last_error fields in metadata."""
+        command_id = uuid4()
+
+        # Register handler that raises TransientCommandError
+        @handler_registry.handler("payments", "DebitAccount")
+        async def handle_debit(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise TransientCommandError("TIMEOUT", "Database connection timeout")
+
+        # Send command
+        await command_bus.send(
+            domain="payments",
+            command_type="DebitAccount",
+            command_id=command_id,
+            data={"account_id": "123", "amount": 100},
+        )
+
+        # Create worker with short backoff for testing
+        worker = Worker(
+            pool,
+            domain="payments",
+            registry=handler_registry,
+            retry_policy=RetryPolicy(max_attempts=3, backoff_schedule=[1, 2, 5]),
+        )
+
+        # Receive and process the command
+        received = await worker.receive()
+        assert len(received) == 1
+
+        # Process the command (should fail and update metadata)
+        await worker.fail(
+            received[0],
+            TransientCommandError("TIMEOUT", "Database connection timeout"),
+        )
+
+        # Check metadata was updated with error info
+        command_repo = PostgresCommandRepository(pool)
+        metadata = await command_repo.get("payments", command_id)
+        assert metadata is not None
+        assert metadata.last_error_type == "TRANSIENT"
+        assert metadata.last_error_code == "TIMEOUT"
+        assert metadata.last_error_msg == "Database connection timeout"
+
+    @pytest.mark.asyncio
+    async def test_transient_error_records_failed_audit_event(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+    ) -> None:
+        """Test that transient error records FAILED audit event."""
+        command_id = uuid4()
+
+        @handler_registry.handler("payments", "DebitAccount")
+        async def handle_debit(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise TransientCommandError("RATE_LIMIT", "Too many requests")
+
+        await command_bus.send(
+            domain="payments",
+            command_type="DebitAccount",
+            command_id=command_id,
+            data={"account_id": "123"},
+        )
+
+        worker = Worker(
+            pool,
+            domain="payments",
+            registry=handler_registry,
+            retry_policy=RetryPolicy(max_attempts=3, backoff_schedule=[1, 2, 5]),
+        )
+
+        received = await worker.receive()
+        await worker.fail(
+            received[0],
+            TransientCommandError("RATE_LIMIT", "Too many requests"),
+        )
+
+        # Check audit trail
+        audit_logger = PostgresAuditLogger(pool)
+        events = await audit_logger.get_events(command_id, domain="payments")
+
+        # Should have SENT, RECEIVED, and FAILED events
+        event_types = [e["event_type"] for e in events]
+        assert AuditEventType.SENT.value in event_types
+        assert AuditEventType.RECEIVED.value in event_types
+        assert AuditEventType.FAILED.value in event_types
+
+        # Check FAILED event details
+        failed_event = next(e for e in events if e["event_type"] == AuditEventType.FAILED.value)
+        assert failed_event["details"]["error_type"] == "TRANSIENT"
+        assert failed_event["details"]["error_code"] == "RATE_LIMIT"
+
+    @pytest.mark.asyncio
+    async def test_message_reappears_after_visibility_timeout(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+    ) -> None:
+        """Test that message reappears after visibility timeout for retry."""
+        command_id = uuid4()
+        attempt_count = 0
+
+        @handler_registry.handler("payments", "DebitAccount")
+        async def handle_debit(command: Command, context: HandlerContext) -> dict[str, str]:
+            nonlocal attempt_count
+            attempt_count = context.attempt
+            if context.attempt < 2:
+                raise TransientCommandError("TIMEOUT", "Temporary failure")
+            return {"status": "success"}
+
+        await command_bus.send(
+            domain="payments",
+            command_type="DebitAccount",
+            command_id=command_id,
+            data={"account_id": "123"},
+        )
+
+        # Use very short visibility timeout for testing
+        worker = Worker(
+            pool,
+            domain="payments",
+            registry=handler_registry,
+            visibility_timeout=1,
+            retry_policy=RetryPolicy(max_attempts=3, backoff_schedule=[1, 2, 5]),
+        )
+
+        # First attempt - should fail
+        received = await worker.receive()
+        assert len(received) == 1
+        assert received[0].context.attempt == 1
+
+        # Simulate failure with 1 second backoff
+        await worker.fail(
+            received[0],
+            TransientCommandError("TIMEOUT", "Temporary failure"),
+        )
+
+        # Wait for message to become visible again
+        await asyncio.sleep(1.5)
+
+        # Second attempt - should succeed
+        received = await worker.receive()
+        assert len(received) == 1
+        assert received[0].context.attempt == 2
+
+    @pytest.mark.asyncio
+    async def test_unknown_exception_treated_as_transient(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+    ) -> None:
+        """Test that unknown exceptions are treated as transient errors."""
+        command_id = uuid4()
+
+        @handler_registry.handler("payments", "DebitAccount")
+        async def handle_debit(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise RuntimeError("Unexpected database error")
+
+        await command_bus.send(
+            domain="payments",
+            command_type="DebitAccount",
+            command_id=command_id,
+            data={"account_id": "123"},
+        )
+
+        worker = Worker(
+            pool,
+            domain="payments",
+            registry=handler_registry,
+            retry_policy=RetryPolicy(max_attempts=3, backoff_schedule=[1, 2, 5]),
+        )
+
+        received = await worker.receive()
+        await worker.fail(received[0], RuntimeError("Unexpected database error"))
+
+        # Check metadata shows TRANSIENT error type
+        command_repo = PostgresCommandRepository(pool)
+        metadata = await command_repo.get("payments", command_id)
+        assert metadata is not None
+        assert metadata.last_error_type == "TRANSIENT"
+        assert metadata.last_error_code == "RuntimeError"
+
+    @pytest.mark.asyncio
+    async def test_backoff_schedule_applied(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+    ) -> None:
+        """Test that backoff schedule is correctly applied to retries."""
+        command_id = uuid4()
+
+        @handler_registry.handler("payments", "DebitAccount")
+        async def handle_debit(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise TransientCommandError("TIMEOUT", "Timeout")
+
+        await command_bus.send(
+            domain="payments",
+            command_type="DebitAccount",
+            command_id=command_id,
+            data={"account_id": "123"},
+        )
+
+        # Custom backoff schedule: 1s, 2s, 5s
+        worker = Worker(
+            pool,
+            domain="payments",
+            registry=handler_registry,
+            visibility_timeout=30,
+            retry_policy=RetryPolicy(max_attempts=4, backoff_schedule=[1, 2, 5]),
+        )
+
+        # First attempt
+        received = await worker.receive()
+        assert received[0].context.attempt == 1
+
+        # Fail with backoff
+        await worker.fail(
+            received[0],
+            TransientCommandError("TIMEOUT", "Timeout"),
+        )
+
+        # Message should not be visible immediately (backoff applied)
+        immediate_receive = await worker.receive(visibility_timeout=1)
+        assert len(immediate_receive) == 0
+
+        # Wait for backoff to expire
+        await asyncio.sleep(1.5)
+
+        # Now should be visible for retry
+        received = await worker.receive()
+        assert len(received) == 1
+        assert received[0].context.attempt == 2
+
+    @pytest.mark.asyncio
+    async def test_worker_run_handles_transient_errors(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+    ) -> None:
+        """Test that worker.run() properly handles transient errors."""
+        command_id = uuid4()
+        processed = asyncio.Event()
+        attempts_seen: list[int] = []
+
+        @handler_registry.handler("payments", "DebitAccount")
+        async def handle_debit(command: Command, context: HandlerContext) -> dict[str, str]:
+            attempts_seen.append(context.attempt)
+            if context.attempt < 2:
+                raise TransientCommandError("TIMEOUT", "First attempt fails")
+            processed.set()
+            return {"status": "success"}
+
+        await command_bus.send(
+            domain="payments",
+            command_type="DebitAccount",
+            command_id=command_id,
+            data={"account_id": "123"},
+        )
+
+        worker = Worker(
+            pool,
+            domain="payments",
+            registry=handler_registry,
+            visibility_timeout=1,
+            retry_policy=RetryPolicy(max_attempts=3, backoff_schedule=[1, 1, 1]),
+        )
+
+        # Run worker for a short time
+        async def run_worker() -> None:
+            await worker.run(concurrency=1, poll_interval=0.5, use_notify=False)
+
+        worker_task = asyncio.create_task(run_worker())
+
+        try:
+            # Wait for successful processing or timeout
+            await asyncio.wait_for(processed.wait(), timeout=5.0)
+
+            # Should have seen at least 2 attempts (first failed, second succeeded)
+            assert len(attempts_seen) >= 2
+            assert 1 in attempts_seen
+            assert 2 in attempts_seen
+
+            # Verify command completed
+            command_repo = PostgresCommandRepository(pool)
+            metadata = await command_repo.get("payments", command_id)
+            assert metadata is not None
+            assert metadata.status == CommandStatus.COMPLETED
+        finally:
+            await worker.stop(timeout=2.0)
+            worker_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await worker_task

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -1,0 +1,102 @@
+"""Unit tests for retry policies."""
+
+from commandbus.policies import DEFAULT_RETRY_POLICY, RetryPolicy
+
+
+class TestRetryPolicy:
+    """Tests for RetryPolicy."""
+
+    def test_default_policy_values(self) -> None:
+        """Test default policy has expected values."""
+        policy = RetryPolicy()
+        assert policy.max_attempts == 3
+        assert policy.backoff_schedule == [10, 60, 300]
+
+    def test_custom_policy_values(self) -> None:
+        """Test custom policy values."""
+        policy = RetryPolicy(max_attempts=5, backoff_schedule=[5, 15, 45, 120])
+        assert policy.max_attempts == 5
+        assert policy.backoff_schedule == [5, 15, 45, 120]
+
+    def test_should_retry_within_max_attempts(self) -> None:
+        """Test should_retry returns True when under max attempts."""
+        policy = RetryPolicy(max_attempts=3)
+        assert policy.should_retry(1) is True
+        assert policy.should_retry(2) is True
+
+    def test_should_retry_at_max_attempts(self) -> None:
+        """Test should_retry returns False at max attempts."""
+        policy = RetryPolicy(max_attempts=3)
+        assert policy.should_retry(3) is False
+
+    def test_should_retry_over_max_attempts(self) -> None:
+        """Test should_retry returns False over max attempts."""
+        policy = RetryPolicy(max_attempts=3)
+        assert policy.should_retry(4) is False
+
+    def test_get_backoff_for_attempt_1(self) -> None:
+        """Test backoff for first attempt uses first schedule value."""
+        policy = RetryPolicy(max_attempts=4, backoff_schedule=[10, 60, 300])
+        assert policy.get_backoff(1) == 10
+
+    def test_get_backoff_for_attempt_2(self) -> None:
+        """Test backoff for second attempt uses second schedule value."""
+        policy = RetryPolicy(max_attempts=4, backoff_schedule=[10, 60, 300])
+        assert policy.get_backoff(2) == 60
+
+    def test_get_backoff_for_attempt_3(self) -> None:
+        """Test backoff for third attempt uses third schedule value."""
+        policy = RetryPolicy(max_attempts=4, backoff_schedule=[10, 60, 300])
+        assert policy.get_backoff(3) == 300
+
+    def test_get_backoff_beyond_schedule_uses_last(self) -> None:
+        """Test backoff beyond schedule length uses last value."""
+        policy = RetryPolicy(max_attempts=10, backoff_schedule=[10, 60, 300])
+        # Attempt 4 and beyond should use 300 (last value)
+        assert policy.get_backoff(4) == 300
+        assert policy.get_backoff(5) == 300
+
+    def test_get_backoff_at_max_attempts_returns_zero(self) -> None:
+        """Test backoff at max attempts returns 0."""
+        policy = RetryPolicy(max_attempts=3, backoff_schedule=[10, 60, 300])
+        assert policy.get_backoff(3) == 0
+
+    def test_get_backoff_over_max_attempts_returns_zero(self) -> None:
+        """Test backoff over max attempts returns 0."""
+        policy = RetryPolicy(max_attempts=3, backoff_schedule=[10, 60, 300])
+        assert policy.get_backoff(4) == 0
+
+    def test_empty_backoff_schedule(self) -> None:
+        """Test handling empty backoff schedule."""
+        policy = RetryPolicy(max_attempts=3, backoff_schedule=[])
+        # Should return default 30
+        assert policy.get_backoff(1) == 30
+
+    def test_default_retry_policy_constant(self) -> None:
+        """Test DEFAULT_RETRY_POLICY is properly configured."""
+        assert DEFAULT_RETRY_POLICY.max_attempts == 3
+        assert DEFAULT_RETRY_POLICY.backoff_schedule == [10, 60, 300]
+
+
+class TestBackoffScheduleScenarios:
+    """Test backoff schedule scenarios from acceptance criteria."""
+
+    def test_backoff_schedule_scenario(self) -> None:
+        """Test the acceptance criteria scenario.
+
+        Given backoff schedule is [10, 60, 300]
+        When the retry policy is applied
+        Then attempt 2 has VT of 10 seconds
+        And attempt 3 has VT of 60 seconds
+        And attempt 4 would have VT of 300 seconds
+        """
+        policy = RetryPolicy(max_attempts=4, backoff_schedule=[10, 60, 300])
+
+        # Attempt 1 -> backoff for retry (index 0)
+        assert policy.get_backoff(1) == 10
+
+        # Attempt 2 -> backoff for retry (index 1)
+        assert policy.get_backoff(2) == 60
+
+        # Attempt 3 -> backoff for retry (index 2)
+        assert policy.get_backoff(3) == 300


### PR DESCRIPTION
## Summary
- Implements S008 - Automatic Retry on Transient Failure (Issue #13)
- Adds `RetryPolicy` class with configurable backoff schedule (default: [10, 60, 300] seconds)
- Adds `Worker.fail()` method for recording failures and applying visibility timeout backoff
- Updates `_process_command` to catch TransientCommandError, PermanentCommandError, and unknown exceptions
- Unknown exceptions are treated as transient errors and retried

## Changes
- New `src/commandbus/policies.py` - RetryPolicy dataclass with backoff calculation
- Updated `src/commandbus/worker.py` - Added fail() method and error handling in _process_command
- Updated `src/commandbus/repositories/command.py` - Added update_error() method
- Added 14 new unit tests for policies and failure handling
- Added 6 new integration tests for retry flow

## Test plan
- [x] Unit tests pass (125 tests, 86% coverage)
- [x] TransientCommandError updates metadata with error info
- [x] FAILED audit event is recorded with error details
- [x] Backoff is applied via set_vt() based on retry policy
- [x] Unknown exceptions are treated as transient
- [x] At max attempts, no backoff is applied (left for exhaustion handling)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)