### PR TITLE
feat(ops): add TroubleshootingQueue for listing commands in TSQ

### DIFF
--- a/src/commandbus/__init__.py
+++ b/src/commandbus/__init__.py
@@ -16,7 +16,9 @@ from commandbus.models import (
     CommandStatus,
     HandlerContext,
     ReplyOutcome,
+    TroubleshootingItem,
 )
+from commandbus.ops.troubleshooting import TroubleshootingQueue
 from commandbus.pgmq.client import PgmqClient, PgmqMessage
 from commandbus.policies import DEFAULT_RETRY_POLICY, RetryPolicy
 from commandbus.repositories.audit import AuditEventType, PostgresAuditLogger
@@ -46,6 +48,8 @@ __all__ = [
     "RetryPolicy",
     "SendResult",
     "TransientCommandError",
+    "TroubleshootingItem",
+    "TroubleshootingQueue",
     "Worker",
 ]
 

--- a/src/commandbus/models.py
+++ b/src/commandbus/models.py
@@ -148,3 +148,38 @@ class Reply:
     data: dict[str, Any] | None = None
     error_code: str | None = None
     error_message: str | None = None
+
+
+@dataclass
+class TroubleshootingItem:
+    """A command in the troubleshooting queue awaiting operator action.
+
+    Attributes:
+        domain: The domain this command belongs to
+        command_id: Unique identifier
+        command_type: Type of command
+        attempts: Number of processing attempts made
+        max_attempts: Maximum allowed attempts
+        last_error_type: Type of last error (TRANSIENT/PERMANENT)
+        last_error_code: Application error code
+        last_error_msg: Error message
+        correlation_id: Correlation ID for tracing
+        reply_to: Reply queue
+        payload: Original command payload from PGMQ archive
+        created_at: When the command was created
+        updated_at: When the command was last updated
+    """
+
+    domain: str
+    command_id: UUID
+    command_type: str
+    attempts: int
+    max_attempts: int
+    last_error_type: str | None
+    last_error_code: str | None
+    last_error_msg: str | None
+    correlation_id: UUID | None
+    reply_to: str | None
+    payload: dict[str, Any] | None
+    created_at: datetime
+    updated_at: datetime

--- a/src/commandbus/ops/__init__.py
+++ b/src/commandbus/ops/__init__.py
@@ -1,1 +1,5 @@
 """Operator APIs."""
+
+from commandbus.ops.troubleshooting import TroubleshootingQueue
+
+__all__ = ["TroubleshootingQueue"]

--- a/src/commandbus/ops/troubleshooting.py
+++ b/src/commandbus/ops/troubleshooting.py
@@ -1,0 +1,170 @@
+"""Troubleshooting queue operations for operators."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from commandbus.models import CommandStatus, TroubleshootingItem
+
+if TYPE_CHECKING:
+    from psycopg_pool import AsyncConnectionPool
+
+logger = logging.getLogger(__name__)
+
+
+def _make_queue_name(domain: str, suffix: str = "commands") -> str:
+    """Create a queue name from domain."""
+    return f"{domain}__{suffix}"
+
+
+class TroubleshootingQueue:
+    """Operations for managing commands in the troubleshooting queue.
+
+    The troubleshooting queue contains commands that failed permanently
+    or exhausted retries. Operators can list, retry, cancel, or complete
+    these commands.
+
+    Example:
+        pool = AsyncConnectionPool(conninfo)
+        await pool.open()
+
+        tsq = TroubleshootingQueue(pool)
+        items = await tsq.list_troubleshooting(domain="payments")
+        for item in items:
+            print(f"{item.command_type}: {item.last_error_msg}")
+    """
+
+    def __init__(self, pool: AsyncConnectionPool[Any]) -> None:
+        """Initialize the troubleshooting queue.
+
+        Args:
+            pool: psycopg async connection pool
+        """
+        self._pool = pool
+
+    async def list_troubleshooting(
+        self,
+        domain: str,
+        command_type: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[TroubleshootingItem]:
+        """List commands in the troubleshooting queue for a domain.
+
+        Retrieves commands with status IN_TROUBLESHOOTING_QUEUE, including
+        the original payload from the PGMQ archive table.
+
+        Args:
+            domain: The domain to list troubleshooting items for
+            command_type: Optional filter by command type
+            limit: Maximum number of items to return (default 50)
+            offset: Number of items to skip for pagination (default 0)
+
+        Returns:
+            List of TroubleshootingItem objects
+        """
+        queue_name = _make_queue_name(domain)
+        archive_table = f"pgmq.a_{queue_name}"
+
+        # Build the query with optional command_type filter
+        query = f"""
+            SELECT
+                c.domain,
+                c.command_id,
+                c.command_type,
+                c.attempts,
+                c.max_attempts,
+                c.last_error_type,
+                c.last_error_code,
+                c.last_error_msg,
+                c.correlation_id,
+                c.reply_queue,
+                a.message,
+                c.created_at,
+                c.updated_at
+            FROM command_bus_command c
+            LEFT JOIN {archive_table} a ON a.message->>'command_id' = c.command_id::text
+            WHERE c.domain = %s
+              AND c.status = %s
+        """
+
+        params: list[Any] = [domain, CommandStatus.IN_TROUBLESHOOTING_QUEUE.value]
+
+        if command_type is not None:
+            query += " AND c.command_type = %s"
+            params.append(command_type)
+
+        query += " ORDER BY c.updated_at DESC LIMIT %s OFFSET %s"
+        params.extend([limit, offset])
+
+        items: list[TroubleshootingItem] = []
+
+        async with self._pool.connection() as conn, conn.cursor() as cur:
+            await cur.execute(query, params)
+            rows = await cur.fetchall()
+
+            for row in rows:
+                # Parse the archived message payload
+                if row[10] is None:
+                    payload = None
+                else:
+                    payload = json.loads(row[10]) if isinstance(row[10], str) else row[10]
+
+                items.append(
+                    TroubleshootingItem(
+                        domain=row[0],
+                        command_id=row[1],
+                        command_type=row[2],
+                        attempts=row[3],
+                        max_attempts=row[4],
+                        last_error_type=row[5],
+                        last_error_code=row[6],
+                        last_error_msg=row[7],
+                        correlation_id=row[8],
+                        reply_to=row[9] if row[9] else None,
+                        payload=payload,
+                        created_at=row[11],
+                        updated_at=row[12],
+                    )
+                )
+
+        logger.debug(
+            f"Listed {len(items)} troubleshooting items for {domain}"
+            f" (limit={limit}, offset={offset})"
+        )
+
+        return items
+
+    async def count_troubleshooting(
+        self,
+        domain: str,
+        command_type: str | None = None,
+    ) -> int:
+        """Count commands in the troubleshooting queue for a domain.
+
+        Args:
+            domain: The domain to count troubleshooting items for
+            command_type: Optional filter by command type
+
+        Returns:
+            Number of commands in troubleshooting queue
+        """
+        query = """
+            SELECT COUNT(*)
+            FROM command_bus_command
+            WHERE domain = %s
+              AND status = %s
+        """
+
+        params: list[Any] = [domain, CommandStatus.IN_TROUBLESHOOTING_QUEUE.value]
+
+        if command_type is not None:
+            query += " AND command_type = %s"
+            params.append(command_type)
+
+        async with self._pool.connection() as conn, conn.cursor() as cur:
+            await cur.execute(query, params)
+            row = await cur.fetchone()
+            return int(row[0]) if row else 0

--- a/tests/integration/test_troubleshooting_queue.py
+++ b/tests/integration/test_troubleshooting_queue.py
@@ -1,0 +1,421 @@
+"""Integration tests for TroubleshootingQueue operations."""
+
+import os
+from uuid import uuid4
+
+import pytest
+from psycopg_pool import AsyncConnectionPool
+
+from commandbus import (
+    Command,
+    CommandBus,
+    HandlerContext,
+    HandlerRegistry,
+    PermanentCommandError,
+    RetryPolicy,
+    TransientCommandError,
+    TroubleshootingQueue,
+    Worker,
+)
+
+
+@pytest.fixture
+def database_url() -> str:
+    """Get database URL from environment."""
+    return os.environ.get(
+        "DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/commandbus"
+    )
+
+
+@pytest.fixture
+async def pool(database_url: str) -> AsyncConnectionPool:
+    """Create a connection pool for testing."""
+    async with AsyncConnectionPool(conninfo=database_url, min_size=1, max_size=5, open=False) as p:
+        yield p
+
+
+@pytest.fixture
+async def command_bus(pool: AsyncConnectionPool) -> CommandBus:
+    """Create a CommandBus with real database connection."""
+    return CommandBus(pool)
+
+
+@pytest.fixture
+def handler_registry() -> HandlerRegistry:
+    """Create handler registry."""
+    return HandlerRegistry()
+
+
+@pytest.fixture
+def tsq(pool: AsyncConnectionPool) -> TroubleshootingQueue:
+    """Create a TroubleshootingQueue."""
+    return TroubleshootingQueue(pool)
+
+
+class TestListTroubleshootingIntegration:
+    """Integration tests for listing troubleshooting queue items."""
+
+    @pytest.mark.asyncio
+    async def test_list_empty_queue(self, tsq: TroubleshootingQueue) -> None:
+        """Test listing empty troubleshooting queue."""
+        # Use a unique domain to ensure we get empty results
+        items = await tsq.list_troubleshooting(f"empty_domain_{uuid4().hex[:8]}")
+
+        assert items == []
+
+    @pytest.mark.asyncio
+    async def test_list_exhausted_command(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+        tsq: TroubleshootingQueue,
+    ) -> None:
+        """Test listing a command that exhausted retries."""
+        command_id = uuid4()
+        domain = f"test_domain_{uuid4().hex[:8]}"
+
+        @handler_registry.handler(domain, "TestCommand")
+        async def handle_test(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise TransientCommandError("TIMEOUT", "Service timeout")
+
+        await command_bus.send(
+            domain=domain,
+            command_type="TestCommand",
+            command_id=command_id,
+            data={"test_key": "test_value"},
+        )
+
+        # Worker with max_attempts=1 (immediate exhaustion)
+        worker = Worker(
+            pool,
+            domain=domain,
+            registry=handler_registry,
+            retry_policy=RetryPolicy(max_attempts=1, backoff_schedule=[1]),
+        )
+
+        # Exhaust the command
+        received = await worker.receive()
+        await worker.fail(received[0], TransientCommandError("TIMEOUT", "Service timeout"))
+
+        # List troubleshooting items
+        items = await tsq.list_troubleshooting(domain)
+
+        assert len(items) == 1
+        item = items[0]
+        assert item.command_id == command_id
+        assert item.command_type == "TestCommand"
+        assert item.domain == domain
+        assert item.last_error_type == "TRANSIENT"
+        assert item.last_error_code == "TIMEOUT"
+        assert item.last_error_msg == "Service timeout"
+
+    @pytest.mark.asyncio
+    async def test_list_permanent_failure_command(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+        tsq: TroubleshootingQueue,
+    ) -> None:
+        """Test listing a command that failed permanently."""
+        command_id = uuid4()
+        domain = f"test_domain_{uuid4().hex[:8]}"
+
+        @handler_registry.handler(domain, "TestCommand")
+        async def handle_test(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise PermanentCommandError("INVALID_DATA", "Invalid account format")
+
+        await command_bus.send(
+            domain=domain,
+            command_type="TestCommand",
+            command_id=command_id,
+            data={"account": "invalid"},
+        )
+
+        worker = Worker(
+            pool,
+            domain=domain,
+            registry=handler_registry,
+        )
+
+        # Fail permanently
+        received = await worker.receive()
+        error = PermanentCommandError("INVALID_DATA", "Invalid account format")
+        await worker.fail(received[0], error)
+
+        # List troubleshooting items
+        items = await tsq.list_troubleshooting(domain)
+
+        assert len(items) == 1
+        item = items[0]
+        assert item.command_id == command_id
+        assert item.last_error_type == "PERMANENT"
+        assert item.last_error_code == "INVALID_DATA"
+
+    @pytest.mark.asyncio
+    async def test_list_with_payload(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+        tsq: TroubleshootingQueue,
+    ) -> None:
+        """Test that listed items include original payload from archive."""
+        command_id = uuid4()
+        domain = f"test_domain_{uuid4().hex[:8]}"
+        original_data = {"account_id": "ACC-123", "amount": 500, "currency": "USD"}
+
+        @handler_registry.handler(domain, "TransferCommand")
+        async def handle_transfer(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise PermanentCommandError("INSUFFICIENT_FUNDS", "Not enough balance")
+
+        await command_bus.send(
+            domain=domain,
+            command_type="TransferCommand",
+            command_id=command_id,
+            data=original_data,
+        )
+
+        worker = Worker(pool, domain=domain, registry=handler_registry)
+        received = await worker.receive()
+        error = PermanentCommandError("INSUFFICIENT_FUNDS", "Not enough balance")
+        await worker.fail(received[0], error)
+
+        items = await tsq.list_troubleshooting(domain)
+
+        assert len(items) == 1
+        assert items[0].payload is not None
+        # Payload contains command envelope including the data
+        assert items[0].payload.get("data") == original_data
+
+    @pytest.mark.asyncio
+    async def test_list_with_command_type_filter(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+        tsq: TroubleshootingQueue,
+    ) -> None:
+        """Test filtering by command type."""
+        domain = f"test_domain_{uuid4().hex[:8]}"
+        debit_id = uuid4()
+        credit_id = uuid4()
+
+        @handler_registry.handler(domain, "DebitCommand")
+        async def handle_debit(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise PermanentCommandError("INVALID", "Invalid")
+
+        @handler_registry.handler(domain, "CreditCommand")
+        async def handle_credit(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise PermanentCommandError("INVALID", "Invalid")
+
+        # Send both commands
+        await command_bus.send(
+            domain=domain,
+            command_type="DebitCommand",
+            command_id=debit_id,
+            data={},
+        )
+        await command_bus.send(
+            domain=domain,
+            command_type="CreditCommand",
+            command_id=credit_id,
+            data={},
+        )
+
+        worker = Worker(pool, domain=domain, registry=handler_registry)
+
+        # Fail both commands
+        for _ in range(2):
+            received = await worker.receive()
+            for cmd in received:
+                await worker.fail(cmd, PermanentCommandError("INVALID", "Invalid"))
+
+        # Filter by DebitCommand
+        debit_items = await tsq.list_troubleshooting(domain, command_type="DebitCommand")
+        assert len(debit_items) == 1
+        assert debit_items[0].command_id == debit_id
+
+        # Filter by CreditCommand
+        credit_items = await tsq.list_troubleshooting(domain, command_type="CreditCommand")
+        assert len(credit_items) == 1
+        assert credit_items[0].command_id == credit_id
+
+    @pytest.mark.asyncio
+    async def test_list_pagination(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+        tsq: TroubleshootingQueue,
+    ) -> None:
+        """Test pagination with limit and offset."""
+        domain = f"test_domain_{uuid4().hex[:8]}"
+
+        @handler_registry.handler(domain, "TestCommand")
+        async def handle_test(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise PermanentCommandError("INVALID", "Invalid")
+
+        # Send 5 commands
+        command_ids = [uuid4() for _ in range(5)]
+        for cid in command_ids:
+            await command_bus.send(
+                domain=domain,
+                command_type="TestCommand",
+                command_id=cid,
+                data={},
+            )
+
+        worker = Worker(pool, domain=domain, registry=handler_registry)
+
+        # Fail all commands
+        while True:
+            received = await worker.receive()
+            if not received:
+                break
+            for cmd in received:
+                await worker.fail(cmd, PermanentCommandError("INVALID", "Invalid"))
+
+        # Test limit
+        page1 = await tsq.list_troubleshooting(domain, limit=2, offset=0)
+        assert len(page1) == 2
+
+        # Test offset
+        page2 = await tsq.list_troubleshooting(domain, limit=2, offset=2)
+        assert len(page2) == 2
+
+        # Ensure no overlap
+        page1_ids = {item.command_id for item in page1}
+        page2_ids = {item.command_id for item in page2}
+        assert page1_ids.isdisjoint(page2_ids)
+
+    @pytest.mark.asyncio
+    async def test_list_with_correlation_id_and_reply_to(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+        tsq: TroubleshootingQueue,
+    ) -> None:
+        """Test that correlation_id and reply_to are preserved."""
+        command_id = uuid4()
+        correlation_id = uuid4()
+        domain = f"test_domain_{uuid4().hex[:8]}"
+        reply_queue = f"{domain}__replies"
+
+        @handler_registry.handler(domain, "TestCommand")
+        async def handle_test(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise PermanentCommandError("FAILED", "Failed")
+
+        await command_bus.send(
+            domain=domain,
+            command_type="TestCommand",
+            command_id=command_id,
+            data={},
+            correlation_id=correlation_id,
+            reply_to=reply_queue,
+        )
+
+        worker = Worker(pool, domain=domain, registry=handler_registry)
+        received = await worker.receive()
+        await worker.fail(received[0], PermanentCommandError("FAILED", "Failed"))
+
+        items = await tsq.list_troubleshooting(domain)
+
+        assert len(items) == 1
+        assert items[0].correlation_id == correlation_id
+        assert items[0].reply_to == reply_queue
+
+
+class TestCountTroubleshootingIntegration:
+    """Integration tests for counting troubleshooting queue items."""
+
+    @pytest.mark.asyncio
+    async def test_count_empty_queue(self, tsq: TroubleshootingQueue) -> None:
+        """Test counting empty troubleshooting queue."""
+        count = await tsq.count_troubleshooting(f"empty_domain_{uuid4().hex[:8]}")
+
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_count_items(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+        tsq: TroubleshootingQueue,
+    ) -> None:
+        """Test counting items in troubleshooting queue."""
+        domain = f"test_domain_{uuid4().hex[:8]}"
+
+        @handler_registry.handler(domain, "TestCommand")
+        async def handle_test(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise PermanentCommandError("INVALID", "Invalid")
+
+        # Send 3 commands
+        for _ in range(3):
+            await command_bus.send(
+                domain=domain,
+                command_type="TestCommand",
+                command_id=uuid4(),
+                data={},
+            )
+
+        worker = Worker(pool, domain=domain, registry=handler_registry)
+
+        # Fail all commands
+        while True:
+            received = await worker.receive()
+            if not received:
+                break
+            for cmd in received:
+                await worker.fail(cmd, PermanentCommandError("INVALID", "Invalid"))
+
+        count = await tsq.count_troubleshooting(domain)
+
+        assert count == 3
+
+    @pytest.mark.asyncio
+    async def test_count_with_command_type_filter(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+        tsq: TroubleshootingQueue,
+    ) -> None:
+        """Test counting with command type filter."""
+        domain = f"test_domain_{uuid4().hex[:8]}"
+
+        @handler_registry.handler(domain, "TypeA")
+        async def handle_a(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise PermanentCommandError("INVALID", "Invalid")
+
+        @handler_registry.handler(domain, "TypeB")
+        async def handle_b(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise PermanentCommandError("INVALID", "Invalid")
+
+        # Send commands: 2 TypeA, 3 TypeB
+        for _ in range(2):
+            await command_bus.send(domain=domain, command_type="TypeA", command_id=uuid4(), data={})
+        for _ in range(3):
+            await command_bus.send(domain=domain, command_type="TypeB", command_id=uuid4(), data={})
+
+        worker = Worker(pool, domain=domain, registry=handler_registry)
+
+        # Fail all commands
+        while True:
+            received = await worker.receive()
+            if not received:
+                break
+            for cmd in received:
+                await worker.fail(cmd, PermanentCommandError("INVALID", "Invalid"))
+
+        # Count by type
+        type_a_count = await tsq.count_troubleshooting(domain, command_type="TypeA")
+        type_b_count = await tsq.count_troubleshooting(domain, command_type="TypeB")
+        total_count = await tsq.count_troubleshooting(domain)
+
+        assert type_a_count == 2
+        assert type_b_count == 3
+        assert total_count == 5

--- a/tests/unit/test_troubleshooting.py
+++ b/tests/unit/test_troubleshooting.py
@@ -1,0 +1,373 @@
+"""Unit tests for TroubleshootingQueue operations."""
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from commandbus.models import CommandStatus
+from commandbus.ops.troubleshooting import TroubleshootingQueue
+
+
+class TestTroubleshootingQueueListTroubleshooting:
+    """Tests for TroubleshootingQueue.list_troubleshooting()."""
+
+    @pytest.fixture
+    def mock_pool(self) -> MagicMock:
+        """Create a mock connection pool with cursor."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+
+        cursor.execute = AsyncMock()
+        cursor.fetchall = AsyncMock(return_value=[])
+
+        @asynccontextmanager
+        async def mock_cursor():
+            yield cursor
+
+        conn.cursor = mock_cursor
+
+        @asynccontextmanager
+        async def mock_connection():
+            yield conn
+
+        pool.connection = mock_connection
+        pool._mock_cursor = cursor
+        return pool
+
+    @pytest.fixture
+    def tsq(self, mock_pool: MagicMock) -> TroubleshootingQueue:
+        """Create a TroubleshootingQueue with mocked pool."""
+        return TroubleshootingQueue(mock_pool)
+
+    @pytest.mark.asyncio
+    async def test_list_empty_returns_empty_list(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test listing when no items in troubleshooting queue."""
+        items = await tsq.list_troubleshooting("payments")
+
+        assert items == []
+        mock_pool._mock_cursor.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_list_returns_items(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test listing returns TroubleshootingItem objects."""
+        command_id = uuid4()
+        correlation_id = uuid4()
+        now = datetime.now(UTC)
+
+        mock_pool._mock_cursor.fetchall = AsyncMock(
+            return_value=[
+                (
+                    "payments",  # domain
+                    command_id,  # command_id
+                    "DebitAccount",  # command_type
+                    3,  # attempts
+                    3,  # max_attempts
+                    "PERMANENT",  # last_error_type
+                    "INVALID_ACCOUNT",  # last_error_code
+                    "Account not found",  # last_error_msg
+                    correlation_id,  # correlation_id
+                    "reply_queue",  # reply_queue
+                    {"amount": 100},  # message (payload as dict)
+                    now,  # created_at
+                    now,  # updated_at
+                ),
+            ]
+        )
+
+        items = await tsq.list_troubleshooting("payments")
+
+        assert len(items) == 1
+        item = items[0]
+        assert item.domain == "payments"
+        assert item.command_id == command_id
+        assert item.command_type == "DebitAccount"
+        assert item.attempts == 3
+        assert item.max_attempts == 3
+        assert item.last_error_type == "PERMANENT"
+        assert item.last_error_code == "INVALID_ACCOUNT"
+        assert item.last_error_msg == "Account not found"
+        assert item.correlation_id == correlation_id
+        assert item.reply_to == "reply_queue"
+        assert item.payload == {"amount": 100}
+        assert item.created_at == now
+        assert item.updated_at == now
+
+    @pytest.mark.asyncio
+    async def test_list_parses_json_string_payload(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test listing parses JSON string payload from archive."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+
+        mock_pool._mock_cursor.fetchall = AsyncMock(
+            return_value=[
+                (
+                    "payments",
+                    command_id,
+                    "DebitAccount",
+                    2,
+                    3,
+                    "TRANSIENT",
+                    "TIMEOUT",
+                    "Service timeout",
+                    None,
+                    None,
+                    '{"amount": 200}',  # JSON string payload
+                    now,
+                    now,
+                ),
+            ]
+        )
+
+        items = await tsq.list_troubleshooting("payments")
+
+        assert len(items) == 1
+        assert items[0].payload == {"amount": 200}
+
+    @pytest.mark.asyncio
+    async def test_list_handles_null_payload(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test listing handles null payload (archive message missing)."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+
+        mock_pool._mock_cursor.fetchall = AsyncMock(
+            return_value=[
+                (
+                    "payments",
+                    command_id,
+                    "DebitAccount",
+                    2,
+                    3,
+                    "TRANSIENT",
+                    "TIMEOUT",
+                    "Service timeout",
+                    None,
+                    None,
+                    None,  # No archived message
+                    now,
+                    now,
+                ),
+            ]
+        )
+
+        items = await tsq.list_troubleshooting("payments")
+
+        assert len(items) == 1
+        assert items[0].payload is None
+
+    @pytest.mark.asyncio
+    async def test_list_handles_null_reply_queue(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test listing handles null reply queue."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+
+        mock_pool._mock_cursor.fetchall = AsyncMock(
+            return_value=[
+                (
+                    "payments",
+                    command_id,
+                    "DebitAccount",
+                    2,
+                    3,
+                    None,
+                    None,
+                    None,
+                    None,
+                    "",  # Empty string reply queue
+                    None,
+                    now,
+                    now,
+                ),
+            ]
+        )
+
+        items = await tsq.list_troubleshooting("payments")
+
+        assert len(items) == 1
+        assert items[0].reply_to is None
+
+    @pytest.mark.asyncio
+    async def test_list_with_command_type_filter(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test listing with command_type filter adds parameter."""
+        await tsq.list_troubleshooting("payments", command_type="DebitAccount")
+
+        call_args = mock_pool._mock_cursor.execute.call_args
+        params = call_args[0][1]
+        assert len(params) == 5  # domain, status, command_type, limit, offset
+        assert params[0] == "payments"
+        assert params[1] == CommandStatus.IN_TROUBLESHOOTING_QUEUE.value
+        assert params[2] == "DebitAccount"
+        assert params[3] == 50  # default limit
+        assert params[4] == 0  # default offset
+
+    @pytest.mark.asyncio
+    async def test_list_with_pagination(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test listing with custom limit and offset."""
+        await tsq.list_troubleshooting("payments", limit=10, offset=20)
+
+        call_args = mock_pool._mock_cursor.execute.call_args
+        params = call_args[0][1]
+        # domain, status, limit, offset (no command_type)
+        assert params[-2] == 10  # limit
+        assert params[-1] == 20  # offset
+
+    @pytest.mark.asyncio
+    async def test_list_multiple_items(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test listing returns multiple items."""
+        now = datetime.now(UTC)
+
+        mock_pool._mock_cursor.fetchall = AsyncMock(
+            return_value=[
+                (
+                    "payments",
+                    uuid4(),
+                    "DebitAccount",
+                    3,
+                    3,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    now,
+                    now,
+                ),
+                (
+                    "payments",
+                    uuid4(),
+                    "CreditAccount",
+                    2,
+                    3,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    now,
+                    now,
+                ),
+                (
+                    "payments",
+                    uuid4(),
+                    "TransferFunds",
+                    1,
+                    3,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    now,
+                    now,
+                ),
+            ]
+        )
+
+        items = await tsq.list_troubleshooting("payments")
+
+        assert len(items) == 3
+        assert items[0].command_type == "DebitAccount"
+        assert items[1].command_type == "CreditAccount"
+        assert items[2].command_type == "TransferFunds"
+
+
+class TestTroubleshootingQueueCountTroubleshooting:
+    """Tests for TroubleshootingQueue.count_troubleshooting()."""
+
+    @pytest.fixture
+    def mock_pool(self) -> MagicMock:
+        """Create a mock connection pool with cursor."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+
+        cursor.execute = AsyncMock()
+        cursor.fetchone = AsyncMock(return_value=(0,))
+
+        @asynccontextmanager
+        async def mock_cursor():
+            yield cursor
+
+        conn.cursor = mock_cursor
+
+        @asynccontextmanager
+        async def mock_connection():
+            yield conn
+
+        pool.connection = mock_connection
+        pool._mock_cursor = cursor
+        return pool
+
+    @pytest.fixture
+    def tsq(self, mock_pool: MagicMock) -> TroubleshootingQueue:
+        """Create a TroubleshootingQueue with mocked pool."""
+        return TroubleshootingQueue(mock_pool)
+
+    @pytest.mark.asyncio
+    async def test_count_returns_zero_when_empty(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test count returns 0 when no items."""
+        count = await tsq.count_troubleshooting("payments")
+
+        assert count == 0
+        mock_pool._mock_cursor.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_count_returns_count(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test count returns correct number."""
+        mock_pool._mock_cursor.fetchone = AsyncMock(return_value=(42,))
+
+        count = await tsq.count_troubleshooting("payments")
+
+        assert count == 42
+
+    @pytest.mark.asyncio
+    async def test_count_with_command_type_filter(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test count with command_type filter adds parameter."""
+        mock_pool._mock_cursor.fetchone = AsyncMock(return_value=(5,))
+
+        count = await tsq.count_troubleshooting("payments", command_type="DebitAccount")
+
+        assert count == 5
+        call_args = mock_pool._mock_cursor.execute.call_args
+        params = call_args[0][1]
+        assert len(params) == 3  # domain, status, command_type
+        assert params[2] == "DebitAccount"
+
+    @pytest.mark.asyncio
+    async def test_count_handles_null_row(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test count returns 0 when fetchone returns None."""
+        mock_pool._mock_cursor.fetchone = AsyncMock(return_value=None)
+
+        count = await tsq.count_troubleshooting("payments")
+
+        assert count == 0


### PR DESCRIPTION
## Summary

- Add `TroubleshootingItem` dataclass for representing commands awaiting operator action
- Add `TroubleshootingQueue` class with `list_troubleshooting()` and `count_troubleshooting()` methods
- Support filtering by command type and pagination (limit/offset)
- Join command metadata with PGMQ archive to include original payload

## Test plan

- [x] Unit tests for `TroubleshootingQueue.list_troubleshooting()` (8 tests)
- [x] Unit tests for `TroubleshootingQueue.count_troubleshooting()` (4 tests)
- [x] Integration tests for list and count operations (10 tests)
- [x] Verify CI passes with coverage ≥80%

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)