### PR TITLE
feat(ops): add operator_retry for retrying commands from troubleshooting queue

### DIFF
--- a/src/commandbus/__init__.py
+++ b/src/commandbus/__init__.py
@@ -3,9 +3,11 @@
 from commandbus.bus import CommandBus, SendResult
 from commandbus.exceptions import (
     CommandBusError,
+    CommandNotFoundError,
     DuplicateCommandError,
     HandlerAlreadyRegisteredError,
     HandlerNotFoundError,
+    InvalidOperationError,
     PermanentCommandError,
     TransientCommandError,
 )
@@ -32,12 +34,14 @@ __all__ = [
     "CommandBus",
     "CommandBusError",
     "CommandMetadata",
+    "CommandNotFoundError",
     "CommandStatus",
     "DuplicateCommandError",
     "HandlerAlreadyRegisteredError",
     "HandlerContext",
     "HandlerNotFoundError",
     "HandlerRegistry",
+    "InvalidOperationError",
     "PermanentCommandError",
     "PgmqClient",
     "PgmqMessage",

--- a/src/commandbus/exceptions.py
+++ b/src/commandbus/exceptions.py
@@ -62,3 +62,19 @@ class PermanentCommandError(CommandBusError):
         self.error_message = message
         self.details = details or {}
         super().__init__(f"[{code}] {message}")
+
+
+class CommandNotFoundError(CommandBusError):
+    """Raised when a command does not exist."""
+
+    def __init__(self, domain: str, command_id: str) -> None:
+        self.domain = domain
+        self.command_id = command_id
+        super().__init__(f"Command {command_id} not found in domain {domain}")
+
+
+class InvalidOperationError(CommandBusError):
+    """Raised when an operation is invalid for the current command state."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)

--- a/tests/unit/test_troubleshooting.py
+++ b/tests/unit/test_troubleshooting.py
@@ -2,12 +2,13 @@
 
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 
-from commandbus.models import CommandStatus
+from commandbus.exceptions import CommandNotFoundError, InvalidOperationError
+from commandbus.models import CommandMetadata, CommandStatus
 from commandbus.ops.troubleshooting import TroubleshootingQueue
 
 
@@ -371,3 +372,335 @@ class TestTroubleshootingQueueCountTroubleshooting:
         count = await tsq.count_troubleshooting("payments")
 
         assert count == 0
+
+
+class TestTroubleshootingQueueOperatorRetry:
+    """Tests for TroubleshootingQueue.operator_retry()."""
+
+    @pytest.fixture
+    def mock_pool(self) -> MagicMock:
+        """Create a mock connection pool with cursor and transaction support."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+
+        cursor.execute = AsyncMock()
+        cursor.fetchone = AsyncMock(return_value=None)
+
+        @asynccontextmanager
+        async def mock_cursor():
+            yield cursor
+
+        conn.cursor = mock_cursor
+        conn.execute = AsyncMock()
+
+        @asynccontextmanager
+        async def mock_transaction():
+            yield
+
+        conn.transaction = mock_transaction
+
+        @asynccontextmanager
+        async def mock_connection():
+            yield conn
+
+        pool.connection = mock_connection
+        pool._mock_cursor = cursor
+        pool._mock_conn = conn
+        return pool
+
+    @pytest.fixture
+    def tsq(self, mock_pool: MagicMock) -> TroubleshootingQueue:
+        """Create a TroubleshootingQueue with mocked pool."""
+        return TroubleshootingQueue(mock_pool)
+
+    @pytest.mark.asyncio
+    async def test_raises_command_not_found_when_missing(self, tsq: TroubleshootingQueue) -> None:
+        """Test raises CommandNotFoundError when command doesn't exist."""
+        command_id = uuid4()
+
+        with patch("commandbus.ops.troubleshooting.PostgresCommandRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_repo.get = AsyncMock(return_value=None)
+            mock_repo_class.return_value = mock_repo
+
+            with pytest.raises(CommandNotFoundError) as exc_info:
+                await tsq.operator_retry("payments", command_id)
+
+            assert exc_info.value.domain == "payments"
+            assert exc_info.value.command_id == str(command_id)
+
+    @pytest.mark.asyncio
+    async def test_raises_invalid_operation_when_not_in_tsq(
+        self, tsq: TroubleshootingQueue
+    ) -> None:
+        """Test raises InvalidOperationError when command not in TSQ."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+
+        metadata = CommandMetadata(
+            domain="payments",
+            command_id=command_id,
+            command_type="DebitAccount",
+            status=CommandStatus.PENDING,  # Not in TSQ
+            attempts=0,
+            max_attempts=3,
+            msg_id=1,
+            correlation_id=None,
+            reply_to=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        with patch("commandbus.ops.troubleshooting.PostgresCommandRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_repo.get = AsyncMock(return_value=metadata)
+            mock_repo_class.return_value = mock_repo
+
+            with pytest.raises(InvalidOperationError) as exc_info:
+                await tsq.operator_retry("payments", command_id)
+
+            assert "not in troubleshooting queue" in str(exc_info.value)
+            assert "PENDING" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_raises_invalid_operation_when_payload_not_found(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test raises InvalidOperationError when payload not in archive."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+
+        metadata = CommandMetadata(
+            domain="payments",
+            command_id=command_id,
+            command_type="DebitAccount",
+            status=CommandStatus.IN_TROUBLESHOOTING_QUEUE,
+            attempts=3,
+            max_attempts=3,
+            msg_id=1,
+            correlation_id=None,
+            reply_to=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        # Cursor returns None for payload query
+        mock_pool._mock_cursor.fetchone = AsyncMock(return_value=None)
+
+        with patch("commandbus.ops.troubleshooting.PostgresCommandRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_repo.get = AsyncMock(return_value=metadata)
+            mock_repo_class.return_value = mock_repo
+
+            with pytest.raises(InvalidOperationError) as exc_info:
+                await tsq.operator_retry("payments", command_id)
+
+            assert "Payload not found in archive" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_successful_retry_returns_new_msg_id(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test successful retry returns new message ID."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+        payload = {"command_id": str(command_id), "data": {"amount": 100}}
+
+        metadata = CommandMetadata(
+            domain="payments",
+            command_id=command_id,
+            command_type="DebitAccount",
+            status=CommandStatus.IN_TROUBLESHOOTING_QUEUE,
+            attempts=3,
+            max_attempts=3,
+            msg_id=1,
+            correlation_id=None,
+            reply_to=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        # Cursor returns payload
+        mock_pool._mock_cursor.fetchone = AsyncMock(return_value=(payload,))
+
+        with (
+            patch("commandbus.ops.troubleshooting.PostgresCommandRepository") as mock_repo_class,
+            patch("commandbus.ops.troubleshooting.PgmqClient") as mock_pgmq_class,
+            patch("commandbus.ops.troubleshooting.PostgresAuditLogger") as mock_audit_class,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get = AsyncMock(return_value=metadata)
+            mock_repo_class.return_value = mock_repo
+
+            mock_pgmq = MagicMock()
+            mock_pgmq.send = AsyncMock(return_value=42)
+            mock_pgmq_class.return_value = mock_pgmq
+
+            mock_audit = MagicMock()
+            mock_audit.log = AsyncMock()
+            mock_audit_class.return_value = mock_audit
+
+            result = await tsq.operator_retry("payments", command_id, operator="admin")
+
+            assert result == 42
+            mock_pgmq.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_updates_command_metadata(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test retry updates command metadata correctly."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+        payload = {"command_id": str(command_id), "data": {"amount": 100}}
+
+        metadata = CommandMetadata(
+            domain="payments",
+            command_id=command_id,
+            command_type="DebitAccount",
+            status=CommandStatus.IN_TROUBLESHOOTING_QUEUE,
+            attempts=3,
+            max_attempts=3,
+            msg_id=1,
+            correlation_id=None,
+            reply_to=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        mock_pool._mock_cursor.fetchone = AsyncMock(return_value=(payload,))
+
+        with (
+            patch("commandbus.ops.troubleshooting.PostgresCommandRepository") as mock_repo_class,
+            patch("commandbus.ops.troubleshooting.PgmqClient") as mock_pgmq_class,
+            patch("commandbus.ops.troubleshooting.PostgresAuditLogger") as mock_audit_class,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get = AsyncMock(return_value=metadata)
+            mock_repo_class.return_value = mock_repo
+
+            mock_pgmq = MagicMock()
+            mock_pgmq.send = AsyncMock(return_value=42)
+            mock_pgmq_class.return_value = mock_pgmq
+
+            mock_audit = MagicMock()
+            mock_audit.log = AsyncMock()
+            mock_audit_class.return_value = mock_audit
+
+            await tsq.operator_retry("payments", command_id)
+
+            # Verify UPDATE was called on the connection
+            mock_pool._mock_conn.execute.assert_called()
+            call_args = mock_pool._mock_conn.execute.call_args
+            query = call_args[0][0]
+            params = call_args[0][1]
+
+            assert "UPDATE command_bus_command" in query
+            assert "status = %s" in query
+            assert "attempts = 0" in query
+            assert CommandStatus.PENDING.value in params
+            assert 42 in params  # new_msg_id
+
+    @pytest.mark.asyncio
+    async def test_records_audit_event(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test retry records OPERATOR_RETRY audit event."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+        payload = {"command_id": str(command_id), "data": {"amount": 100}}
+
+        metadata = CommandMetadata(
+            domain="payments",
+            command_id=command_id,
+            command_type="DebitAccount",
+            status=CommandStatus.IN_TROUBLESHOOTING_QUEUE,
+            attempts=3,
+            max_attempts=3,
+            msg_id=1,
+            correlation_id=None,
+            reply_to=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        mock_pool._mock_cursor.fetchone = AsyncMock(return_value=(payload,))
+
+        with (
+            patch("commandbus.ops.troubleshooting.PostgresCommandRepository") as mock_repo_class,
+            patch("commandbus.ops.troubleshooting.PgmqClient") as mock_pgmq_class,
+            patch("commandbus.ops.troubleshooting.PostgresAuditLogger") as mock_audit_class,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get = AsyncMock(return_value=metadata)
+            mock_repo_class.return_value = mock_repo
+
+            mock_pgmq = MagicMock()
+            mock_pgmq.send = AsyncMock(return_value=42)
+            mock_pgmq_class.return_value = mock_pgmq
+
+            mock_audit = MagicMock()
+            mock_audit.log = AsyncMock()
+            mock_audit_class.return_value = mock_audit
+
+            await tsq.operator_retry("payments", command_id, operator="admin_user")
+
+            mock_audit.log.assert_called_once()
+            call_kwargs = mock_audit.log.call_args[1]
+            assert call_kwargs["domain"] == "payments"
+            assert call_kwargs["command_id"] == command_id
+            assert call_kwargs["event_type"].value == "OPERATOR_RETRY"
+            assert call_kwargs["details"]["operator"] == "admin_user"
+            assert call_kwargs["details"]["new_msg_id"] == 42
+
+    @pytest.mark.asyncio
+    async def test_parses_json_string_payload(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test retry parses JSON string payload from archive."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+        payload_str = '{"command_id": "test", "data": {"amount": 100}}'
+
+        metadata = CommandMetadata(
+            domain="payments",
+            command_id=command_id,
+            command_type="DebitAccount",
+            status=CommandStatus.IN_TROUBLESHOOTING_QUEUE,
+            attempts=3,
+            max_attempts=3,
+            msg_id=1,
+            correlation_id=None,
+            reply_to=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        # Return JSON string instead of dict
+        mock_pool._mock_cursor.fetchone = AsyncMock(return_value=(payload_str,))
+
+        with (
+            patch("commandbus.ops.troubleshooting.PostgresCommandRepository") as mock_repo_class,
+            patch("commandbus.ops.troubleshooting.PgmqClient") as mock_pgmq_class,
+            patch("commandbus.ops.troubleshooting.PostgresAuditLogger") as mock_audit_class,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get = AsyncMock(return_value=metadata)
+            mock_repo_class.return_value = mock_repo
+
+            mock_pgmq = MagicMock()
+            mock_pgmq.send = AsyncMock(return_value=42)
+            mock_pgmq_class.return_value = mock_pgmq
+
+            mock_audit = MagicMock()
+            mock_audit.log = AsyncMock()
+            mock_audit_class.return_value = mock_audit
+
+            result = await tsq.operator_retry("payments", command_id)
+
+            assert result == 42
+            # Verify payload was parsed and sent
+            mock_pgmq.send.assert_called_once()
+            sent_payload = mock_pgmq.send.call_args[0][1]
+            assert sent_payload == {"command_id": "test", "data": {"amount": 100}}


### PR DESCRIPTION
## Summary
- Add `CommandNotFoundError` and `InvalidOperationError` exceptions for operator actions
- Implement `operator_retry()` method in `TroubleshootingQueue` class
- Retrieves original payload from archive, re-enqueues to PGMQ, resets attempts to 0, sets status to PENDING
- Records `OPERATOR_RETRY` audit event with operator identity
- Validates command exists and is in troubleshooting queue before retry

## Test plan
- [x] Unit tests for error cases (command not found, not in TSQ, payload missing)
- [x] Unit tests for successful retry (returns msg_id, updates metadata, records audit)
- [x] Integration tests for full retry flow with database
- [x] Integration tests verifying command can be processed again after retry
- [x] All 156 unit tests pass
- [x] Linting and formatting checks pass

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)