### PR TITLE
feat(ops): add operator_cancel for canceling commands in troubleshooting queue

### DIFF
--- a/tests/integration/test_troubleshooting_queue.py
+++ b/tests/integration/test_troubleshooting_queue.py
@@ -15,6 +15,7 @@ from commandbus import (
     HandlerRegistry,
     InvalidOperationError,
     PermanentCommandError,
+    PgmqClient,
     PostgresAuditLogger,
     PostgresCommandRepository,
     RetryPolicy,
@@ -651,6 +652,221 @@ class TestOperatorRetryIntegration:
 
         # Retry the command
         await tsq.operator_retry(domain, command_id)
+
+        # Verify no longer in TSQ
+        count_after = await tsq.count_troubleshooting(domain)
+        assert count_after == 0
+
+        items = await tsq.list_troubleshooting(domain)
+        assert len(items) == 0
+
+
+class TestOperatorCancelIntegration:
+    """Integration tests for operator_cancel()."""
+
+    @pytest.mark.asyncio
+    async def test_operator_cancel_raises_command_not_found(
+        self, tsq: TroubleshootingQueue
+    ) -> None:
+        """Test operator_cancel raises CommandNotFoundError for missing command."""
+        command_id = uuid4()
+        domain = f"test_domain_{uuid4().hex[:8]}"
+
+        with pytest.raises(CommandNotFoundError) as exc_info:
+            await tsq.operator_cancel(domain, command_id, "Invalid account")
+
+        assert exc_info.value.domain == domain
+        assert exc_info.value.command_id == str(command_id)
+
+    @pytest.mark.asyncio
+    async def test_operator_cancel_raises_invalid_operation_not_in_tsq(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+        tsq: TroubleshootingQueue,
+    ) -> None:
+        """Test operator_cancel raises InvalidOperationError when command not in TSQ."""
+        command_id = uuid4()
+        domain = f"test_domain_{uuid4().hex[:8]}"
+
+        @handler_registry.handler(domain, "TestCommand")
+        async def handle_test(command: Command, context: HandlerContext) -> dict[str, str]:
+            return {"status": "ok"}
+
+        # Send command - it will be in PENDING status
+        await command_bus.send(
+            domain=domain,
+            command_type="TestCommand",
+            command_id=command_id,
+            data={"test": "data"},
+        )
+
+        with pytest.raises(InvalidOperationError) as exc_info:
+            await tsq.operator_cancel(domain, command_id, "Invalid account")
+
+        assert "not in troubleshooting queue" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_operator_cancel_sets_status_to_canceled(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+        tsq: TroubleshootingQueue,
+    ) -> None:
+        """Test operator_cancel sets command status to CANCELED."""
+        command_id = uuid4()
+        domain = f"test_domain_{uuid4().hex[:8]}"
+
+        @handler_registry.handler(domain, "TestCommand")
+        async def handle_test(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise PermanentCommandError("INVALID", "Invalid")
+
+        # Send and fail the command to put it in TSQ
+        await command_bus.send(
+            domain=domain,
+            command_type="TestCommand",
+            command_id=command_id,
+            data={},
+        )
+
+        worker = Worker(pool, domain=domain, registry=handler_registry)
+        received = await worker.receive()
+        await worker.fail(received[0], PermanentCommandError("INVALID", "Invalid"))
+
+        # Cancel the command
+        await tsq.operator_cancel(domain, command_id, "Invalid account")
+
+        # Verify command is now CANCELED
+        command_repo = PostgresCommandRepository(pool)
+        metadata = await command_repo.get(domain, command_id)
+        assert metadata is not None
+        assert metadata.status == CommandStatus.CANCELED
+
+    @pytest.mark.asyncio
+    async def test_operator_cancel_sends_reply(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+        tsq: TroubleshootingQueue,
+    ) -> None:
+        """Test operator_cancel sends CANCELED reply to reply queue."""
+        command_id = uuid4()
+        correlation_id = uuid4()
+        domain = f"test_domain_{uuid4().hex[:8]}"
+        reply_queue = f"{domain}__replies"
+
+        @handler_registry.handler(domain, "TestCommand")
+        async def handle_test(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise PermanentCommandError("INVALID", "Invalid")
+
+        # Create reply queue
+        pgmq = PgmqClient(pool)
+        await pgmq.create_queue(reply_queue)
+
+        # Send command with reply_to
+        await command_bus.send(
+            domain=domain,
+            command_type="TestCommand",
+            command_id=command_id,
+            data={},
+            correlation_id=correlation_id,
+            reply_to=reply_queue,
+        )
+
+        worker = Worker(pool, domain=domain, registry=handler_registry)
+        received = await worker.receive()
+        await worker.fail(received[0], PermanentCommandError("INVALID", "Invalid"))
+
+        # Cancel the command
+        await tsq.operator_cancel(domain, command_id, "Invalid account format")
+
+        # Read the reply from the queue
+        replies = await pgmq.read(reply_queue, visibility_timeout=30, batch_size=1)
+
+        assert len(replies) == 1
+        reply = replies[0].message
+        assert reply["command_id"] == str(command_id)
+        assert reply["correlation_id"] == str(correlation_id)
+        assert reply["outcome"] == "CANCELED"
+        assert reply["reason"] == "Invalid account format"
+
+    @pytest.mark.asyncio
+    async def test_operator_cancel_records_audit_event(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+        tsq: TroubleshootingQueue,
+    ) -> None:
+        """Test operator_cancel records OPERATOR_CANCEL audit event."""
+        command_id = uuid4()
+        domain = f"test_domain_{uuid4().hex[:8]}"
+
+        @handler_registry.handler(domain, "TestCommand")
+        async def handle_test(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise PermanentCommandError("INVALID", "Invalid")
+
+        # Send and fail the command
+        await command_bus.send(
+            domain=domain,
+            command_type="TestCommand",
+            command_id=command_id,
+            data={},
+        )
+
+        worker = Worker(pool, domain=domain, registry=handler_registry)
+        received = await worker.receive()
+        await worker.fail(received[0], PermanentCommandError("INVALID", "Invalid"))
+
+        # Cancel with operator identity and reason
+        await tsq.operator_cancel(domain, command_id, "Duplicate request", operator="admin_user")
+
+        # Verify audit event was recorded
+        audit_logger = PostgresAuditLogger(pool)
+        events = await audit_logger.get_events(command_id, domain)
+
+        cancel_events = [e for e in events if e["event_type"] == "OPERATOR_CANCEL"]
+        assert len(cancel_events) == 1
+        assert cancel_events[0]["details"]["operator"] == "admin_user"
+        assert cancel_events[0]["details"]["reason"] == "Duplicate request"
+
+    @pytest.mark.asyncio
+    async def test_operator_cancel_removes_from_tsq_list(
+        self,
+        pool: AsyncConnectionPool,
+        command_bus: CommandBus,
+        handler_registry: HandlerRegistry,
+        tsq: TroubleshootingQueue,
+    ) -> None:
+        """Test canceled command no longer appears in troubleshooting list."""
+        command_id = uuid4()
+        domain = f"test_domain_{uuid4().hex[:8]}"
+
+        @handler_registry.handler(domain, "TestCommand")
+        async def handle_test(command: Command, context: HandlerContext) -> dict[str, str]:
+            raise PermanentCommandError("INVALID", "Invalid")
+
+        # Send and fail the command
+        await command_bus.send(
+            domain=domain,
+            command_type="TestCommand",
+            command_id=command_id,
+            data={},
+        )
+
+        worker = Worker(pool, domain=domain, registry=handler_registry)
+        received = await worker.receive()
+        await worker.fail(received[0], PermanentCommandError("INVALID", "Invalid"))
+
+        # Verify in TSQ
+        count_before = await tsq.count_troubleshooting(domain)
+        assert count_before == 1
+
+        # Cancel the command
+        await tsq.operator_cancel(domain, command_id, "Invalid request")
 
         # Verify no longer in TSQ
         count_after = await tsq.count_troubleshooting(domain)

--- a/tests/unit/test_troubleshooting.py
+++ b/tests/unit/test_troubleshooting.py
@@ -704,3 +704,338 @@ class TestTroubleshootingQueueOperatorRetry:
             mock_pgmq.send.assert_called_once()
             sent_payload = mock_pgmq.send.call_args[0][1]
             assert sent_payload == {"command_id": "test", "data": {"amount": 100}}
+
+
+class TestTroubleshootingQueueOperatorCancel:
+    """Tests for TroubleshootingQueue.operator_cancel()."""
+
+    @pytest.fixture
+    def mock_pool(self) -> MagicMock:
+        """Create a mock connection pool with cursor and transaction support."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+
+        cursor.execute = AsyncMock()
+        cursor.fetchone = AsyncMock(return_value=None)
+
+        @asynccontextmanager
+        async def mock_cursor():
+            yield cursor
+
+        conn.cursor = mock_cursor
+        conn.execute = AsyncMock()
+
+        @asynccontextmanager
+        async def mock_transaction():
+            yield
+
+        conn.transaction = mock_transaction
+
+        @asynccontextmanager
+        async def mock_connection():
+            yield conn
+
+        pool.connection = mock_connection
+        pool._mock_cursor = cursor
+        pool._mock_conn = conn
+        return pool
+
+    @pytest.fixture
+    def tsq(self, mock_pool: MagicMock) -> TroubleshootingQueue:
+        """Create a TroubleshootingQueue with mocked pool."""
+        return TroubleshootingQueue(mock_pool)
+
+    @pytest.mark.asyncio
+    async def test_raises_command_not_found_when_missing(self, tsq: TroubleshootingQueue) -> None:
+        """Test raises CommandNotFoundError when command doesn't exist."""
+        command_id = uuid4()
+
+        with patch("commandbus.ops.troubleshooting.PostgresCommandRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_repo.get = AsyncMock(return_value=None)
+            mock_repo_class.return_value = mock_repo
+
+            with pytest.raises(CommandNotFoundError) as exc_info:
+                await tsq.operator_cancel("payments", command_id, "Invalid account")
+
+            assert exc_info.value.domain == "payments"
+            assert exc_info.value.command_id == str(command_id)
+
+    @pytest.mark.asyncio
+    async def test_raises_invalid_operation_when_not_in_tsq(
+        self, tsq: TroubleshootingQueue
+    ) -> None:
+        """Test raises InvalidOperationError when command not in TSQ."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+
+        metadata = CommandMetadata(
+            domain="payments",
+            command_id=command_id,
+            command_type="DebitAccount",
+            status=CommandStatus.PENDING,  # Not in TSQ
+            attempts=0,
+            max_attempts=3,
+            msg_id=1,
+            correlation_id=None,
+            reply_to=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        with patch("commandbus.ops.troubleshooting.PostgresCommandRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_repo.get = AsyncMock(return_value=metadata)
+            mock_repo_class.return_value = mock_repo
+
+            with pytest.raises(InvalidOperationError) as exc_info:
+                await tsq.operator_cancel("payments", command_id, "Invalid account")
+
+            assert "not in troubleshooting queue" in str(exc_info.value)
+            assert "PENDING" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_cancel_sets_status_to_canceled(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test cancel sets command status to CANCELED."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+
+        metadata = CommandMetadata(
+            domain="payments",
+            command_id=command_id,
+            command_type="DebitAccount",
+            status=CommandStatus.IN_TROUBLESHOOTING_QUEUE,
+            attempts=3,
+            max_attempts=3,
+            msg_id=1,
+            correlation_id=None,
+            reply_to=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        with (
+            patch("commandbus.ops.troubleshooting.PostgresCommandRepository") as mock_repo_class,
+            patch("commandbus.ops.troubleshooting.PgmqClient") as mock_pgmq_class,
+            patch("commandbus.ops.troubleshooting.PostgresAuditLogger") as mock_audit_class,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get = AsyncMock(return_value=metadata)
+            mock_repo_class.return_value = mock_repo
+
+            mock_pgmq = MagicMock()
+            mock_pgmq.send = AsyncMock(return_value=42)
+            mock_pgmq_class.return_value = mock_pgmq
+
+            mock_audit = MagicMock()
+            mock_audit.log = AsyncMock()
+            mock_audit_class.return_value = mock_audit
+
+            await tsq.operator_cancel("payments", command_id, "Invalid account")
+
+            # Verify UPDATE was called on the connection
+            mock_pool._mock_conn.execute.assert_called()
+            call_args = mock_pool._mock_conn.execute.call_args
+            query = call_args[0][0]
+            params = call_args[0][1]
+
+            assert "UPDATE command_bus_command" in query
+            assert "status = %s" in query
+            assert CommandStatus.CANCELED.value in params
+
+    @pytest.mark.asyncio
+    async def test_cancel_sends_reply_when_reply_to_configured(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test cancel sends CANCELED reply when reply_to is configured."""
+        command_id = uuid4()
+        correlation_id = uuid4()
+        now = datetime.now(UTC)
+
+        metadata = CommandMetadata(
+            domain="payments",
+            command_id=command_id,
+            command_type="DebitAccount",
+            status=CommandStatus.IN_TROUBLESHOOTING_QUEUE,
+            attempts=3,
+            max_attempts=3,
+            msg_id=1,
+            correlation_id=correlation_id,
+            reply_to="payments__replies",
+            created_at=now,
+            updated_at=now,
+        )
+
+        with (
+            patch("commandbus.ops.troubleshooting.PostgresCommandRepository") as mock_repo_class,
+            patch("commandbus.ops.troubleshooting.PgmqClient") as mock_pgmq_class,
+            patch("commandbus.ops.troubleshooting.PostgresAuditLogger") as mock_audit_class,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get = AsyncMock(return_value=metadata)
+            mock_repo_class.return_value = mock_repo
+
+            mock_pgmq = MagicMock()
+            mock_pgmq.send = AsyncMock(return_value=42)
+            mock_pgmq_class.return_value = mock_pgmq
+
+            mock_audit = MagicMock()
+            mock_audit.log = AsyncMock()
+            mock_audit_class.return_value = mock_audit
+
+            await tsq.operator_cancel("payments", command_id, "Invalid account")
+
+            # Verify reply was sent
+            mock_pgmq.send.assert_called_once()
+            queue_name = mock_pgmq.send.call_args[0][0]
+            reply_message = mock_pgmq.send.call_args[0][1]
+
+            assert queue_name == "payments__replies"
+            assert reply_message["command_id"] == str(command_id)
+            assert reply_message["correlation_id"] == str(correlation_id)
+            assert reply_message["outcome"] == "CANCELED"
+            assert reply_message["reason"] == "Invalid account"
+
+    @pytest.mark.asyncio
+    async def test_cancel_does_not_send_reply_when_no_reply_to(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test cancel does not send reply when reply_to is not configured."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+
+        metadata = CommandMetadata(
+            domain="payments",
+            command_id=command_id,
+            command_type="DebitAccount",
+            status=CommandStatus.IN_TROUBLESHOOTING_QUEUE,
+            attempts=3,
+            max_attempts=3,
+            msg_id=1,
+            correlation_id=None,
+            reply_to=None,  # No reply queue
+            created_at=now,
+            updated_at=now,
+        )
+
+        with (
+            patch("commandbus.ops.troubleshooting.PostgresCommandRepository") as mock_repo_class,
+            patch("commandbus.ops.troubleshooting.PgmqClient") as mock_pgmq_class,
+            patch("commandbus.ops.troubleshooting.PostgresAuditLogger") as mock_audit_class,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get = AsyncMock(return_value=metadata)
+            mock_repo_class.return_value = mock_repo
+
+            mock_pgmq = MagicMock()
+            mock_pgmq.send = AsyncMock(return_value=42)
+            mock_pgmq_class.return_value = mock_pgmq
+
+            mock_audit = MagicMock()
+            mock_audit.log = AsyncMock()
+            mock_audit_class.return_value = mock_audit
+
+            await tsq.operator_cancel("payments", command_id, "Invalid account")
+
+            # Verify no reply was sent
+            mock_pgmq.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancel_records_audit_event(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test cancel records OPERATOR_CANCEL audit event."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+
+        metadata = CommandMetadata(
+            domain="payments",
+            command_id=command_id,
+            command_type="DebitAccount",
+            status=CommandStatus.IN_TROUBLESHOOTING_QUEUE,
+            attempts=3,
+            max_attempts=3,
+            msg_id=1,
+            correlation_id=None,
+            reply_to="payments__replies",
+            created_at=now,
+            updated_at=now,
+        )
+
+        with (
+            patch("commandbus.ops.troubleshooting.PostgresCommandRepository") as mock_repo_class,
+            patch("commandbus.ops.troubleshooting.PgmqClient") as mock_pgmq_class,
+            patch("commandbus.ops.troubleshooting.PostgresAuditLogger") as mock_audit_class,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get = AsyncMock(return_value=metadata)
+            mock_repo_class.return_value = mock_repo
+
+            mock_pgmq = MagicMock()
+            mock_pgmq.send = AsyncMock(return_value=42)
+            mock_pgmq_class.return_value = mock_pgmq
+
+            mock_audit = MagicMock()
+            mock_audit.log = AsyncMock()
+            mock_audit_class.return_value = mock_audit
+
+            await tsq.operator_cancel(
+                "payments", command_id, "Invalid account", operator="admin_user"
+            )
+
+            mock_audit.log.assert_called_once()
+            call_kwargs = mock_audit.log.call_args[1]
+            assert call_kwargs["domain"] == "payments"
+            assert call_kwargs["command_id"] == command_id
+            assert call_kwargs["event_type"].value == "OPERATOR_CANCEL"
+            assert call_kwargs["details"]["operator"] == "admin_user"
+            assert call_kwargs["details"]["reason"] == "Invalid account"
+            assert call_kwargs["details"]["reply_to"] == "payments__replies"
+
+    @pytest.mark.asyncio
+    async def test_cancel_includes_reason_in_audit(
+        self, tsq: TroubleshootingQueue, mock_pool: MagicMock
+    ) -> None:
+        """Test cancel includes reason in audit event details."""
+        command_id = uuid4()
+        now = datetime.now(UTC)
+
+        metadata = CommandMetadata(
+            domain="payments",
+            command_id=command_id,
+            command_type="DebitAccount",
+            status=CommandStatus.IN_TROUBLESHOOTING_QUEUE,
+            attempts=3,
+            max_attempts=3,
+            msg_id=1,
+            correlation_id=None,
+            reply_to=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        with (
+            patch("commandbus.ops.troubleshooting.PostgresCommandRepository") as mock_repo_class,
+            patch("commandbus.ops.troubleshooting.PgmqClient") as mock_pgmq_class,
+            patch("commandbus.ops.troubleshooting.PostgresAuditLogger") as mock_audit_class,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get = AsyncMock(return_value=metadata)
+            mock_repo_class.return_value = mock_repo
+
+            mock_pgmq = MagicMock()
+            mock_pgmq_class.return_value = mock_pgmq
+
+            mock_audit = MagicMock()
+            mock_audit.log = AsyncMock()
+            mock_audit_class.return_value = mock_audit
+
+            await tsq.operator_cancel(
+                "payments", command_id, "Duplicate request - already processed"
+            )
+
+            call_kwargs = mock_audit.log.call_args[1]
+            assert call_kwargs["details"]["reason"] == "Duplicate request - already processed"


### PR DESCRIPTION
## Summary
- Add `operator_cancel()` method to `TroubleshootingQueue` class
- Sets command status to `CANCELED`
- Sends `CANCELED` reply to the `reply_to` queue (if configured) with the cancellation reason
- Records `OPERATOR_CANCEL` audit event with operator identity and reason
- Validates command is in troubleshooting queue before canceling

## Test plan
- [x] Unit tests for error cases (command not found, not in TSQ)
- [x] Unit tests for successful cancel (sets status, sends reply, records audit)
- [x] Unit test for skipping reply when no reply_to configured
- [x] Integration tests for full cancel flow with database
- [x] Integration test verifying reply is received on reply queue
- [x] All 163 unit tests pass
- [x] Linting and formatting checks pass

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)