### PR TITLE
chore: add make ready target and fix pre-commit workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-lets # Pre-commit hooks for Command Bus
+# Pre-commit hooks for Command Bus
 # Install: make install-dev (runs pre-commit install)
 # Run manually: make pre-commit
 
@@ -43,7 +43,6 @@ repos:
     rev: v1.5.0
     hooks:
       - id: detect-secrets
-        args: [--baseline, .secrets.baseline]
         exclude: package.lock.json
 
   # Validate pyproject.toml
@@ -57,7 +56,7 @@ repos:
     hooks:
       - id: coverage-check
         name: coverage-check
-        entry: bash -c 'pytest --cov=src/commandbus --cov-branch --cov-fail-under=80 tests/unit/ -q --no-header || (echo "ERROR: Coverage below 80%. Add tests before committing." && exit 1)'
+        entry: "bash -c 'uv run pytest --cov=src/commandbus --cov-branch --cov-fail-under=80 tests/unit/ -q --no-header || (echo ERROR: Coverage below 80%. Add tests before committing. && exit 1)'"
         language: system
         pass_filenames: false
         always_run: true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev lint format typecheck test test-unit test-integration test-e2e coverage docker-up docker-down clean
+.PHONY: help install install-dev lint format typecheck test test-unit test-integration test-e2e coverage docker-up docker-down clean ready
 
 # Default target
 help:
@@ -13,6 +13,7 @@ help:
 	@echo "  make format         Format code (ruff format)"
 	@echo "  make typecheck      Run type checker (mypy)"
 	@echo "  make check          Run all quality checks"
+	@echo "  make ready          Run all checks before commit (format + lint + typecheck + test)"
 	@echo ""
 	@echo "Testing:"
 	@echo "  make test           Run all tests"
@@ -59,6 +60,11 @@ typecheck:
 
 check: lint typecheck
 	@echo "All checks passed!"
+
+# Run all checks before commit - use this before every git commit
+ready: format lint typecheck test-coverage
+	@echo ""
+	@echo "✅ All checks passed! Ready to commit."
 
 # =============================================================================
 # Testing


### PR DESCRIPTION
## Summary
- Fix typo in .pre-commit-config.yaml
- Fix YAML quoting issue in coverage-check entry
- Fix coverage-check to use `uv run pytest`
- Remove secrets baseline requirement
- Add `make ready` target that runs: format → lint → typecheck → test-coverage
- Update CLAUDE.md with clearer verification checklist

## Motivation
CI failed because formatting wasn't checked locally before pushing. This change enforces:
1. Local checks via `make ready` before every commit
2. Pre-commit hooks for automated enforcement
3. Clearer instructions in CLAUDE.md

## Test plan
- [x] Pre-commit hooks pass
- [x] `make ready` passes
- [ ] GitHub Actions passes

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)