### PR TITLE
fix(e2e): Replace mock data with real database queries (#66)

### DIFF
--- a/tests/e2e/app/__init__.py
+++ b/tests/e2e/app/__init__.py
@@ -1,6 +1,11 @@
 """E2E Demo Application - Flask app factory."""
 
+import asyncio
+import atexit
+import contextlib
+
 from flask import Flask
+from psycopg_pool import AsyncConnectionPool
 
 from .config import Config
 
@@ -9,6 +14,9 @@ def create_app(config_class: type = Config) -> Flask:
     """Create and configure the Flask application."""
     app = Flask(__name__)
     app.config.from_object(config_class)
+
+    # Initialize database pool
+    _init_database(app)
 
     # Register blueprints
     from .web.routes import web_bp
@@ -20,3 +28,37 @@ def create_app(config_class: type = Config) -> Flask:
     app.register_blueprint(api_bp, url_prefix="/api/v1")
 
     return app
+
+
+def _init_database(app: Flask) -> None:
+    """Initialize the async database connection pool."""
+    database_url = app.config.get("DATABASE_URL", Config.DATABASE_URL)
+
+    # Create pool (will be opened on first use)
+    pool = AsyncConnectionPool(
+        conninfo=database_url,
+        min_size=2,
+        max_size=10,
+        open=False,
+    )
+
+    # Store pool in app config for access in routes
+    app.config["pool"] = pool
+    app.config["pool_opened"] = False
+
+    # Register cleanup on app shutdown
+    @atexit.register
+    def close_pool() -> None:
+        if app.config.get("pool_opened"):
+            with contextlib.suppress(Exception):
+                asyncio.get_event_loop().run_until_complete(pool.close())
+
+
+def run_async(coro):
+    """Helper to run async code in sync Flask context."""
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop.run_until_complete(coro)


### PR DESCRIPTION
## Summary
- Add database connection pool to Flask app factory
- Implement `run_async` helper for bridging sync Flask with async psycopg
- Replace all mock data generation with real SQL queries against `commandbus` database
- Integrate CommandBus for sending commands via `/api/v1/commands` endpoints
- Integrate TroubleshootingQueue for TSQ operations
- Add graceful error handling with fallback defaults on database errors

All API endpoints now query the real database using the `e2e` domain for isolation.

## Test plan
- [ ] Start database with `make docker-up`
- [ ] Run `make e2e-setup` to create E2E tables and queues
- [ ] Start the app with `make e2e-app`
- [ ] Verify `/api/v1/health` returns `{"status": "ok", "database": "connected"}`
- [ ] Verify `/api/v1/stats/overview` returns zeros (empty database)
- [ ] Create a command via `/api/v1/commands` and verify it appears in command list
- [ ] Verify dashboard updates with real data

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)