### PR TITLE
chore: update to latest package versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,10 @@ test = [
     "testcontainers[postgres]>=4.0.0",
 ]
 e2e = [
-    "fastapi>=0.115.0",
-    "uvicorn[standard]>=0.32.0",
-    "jinja2>=3.1.4",
-    "python-multipart>=0.0.9",
+    "fastapi>=0.128.0",
+    "uvicorn[standard]>=0.40.0",
+    "jinja2>=3.1.6",
+    "python-multipart>=0.0.20",
     "python-dotenv>=1.0.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -179,8 +179,8 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastapi", marker = "extra == 'e2e'", specifier = ">=0.115.0" },
-    { name = "jinja2", marker = "extra == 'e2e'", specifier = ">=3.1.4" },
+    { name = "fastapi", marker = "extra == 'e2e'", specifier = ">=0.128.0" },
+    { name = "jinja2", marker = "extra == 'e2e'", specifier = ">=3.1.6" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
     { name = "orjson", specifier = ">=3.10.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
@@ -192,10 +192,10 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0.0" },
     { name = "python-dotenv", marker = "extra == 'e2e'", specifier = ">=1.0.1" },
-    { name = "python-multipart", marker = "extra == 'e2e'", specifier = ">=0.0.9" },
+    { name = "python-multipart", marker = "extra == 'e2e'", specifier = ">=0.0.20" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'test'", specifier = ">=4.0.0" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'e2e'", specifier = ">=0.32.0" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'e2e'", specifier = ">=0.40.0" },
 ]
 provides-extras = ["dev", "test", "e2e"]
 


### PR DESCRIPTION
- fastapi: >=0.115.0 -> >=0.128.0
- uvicorn: >=0.32.0 -> >=0.40.0
- jinja2: >=3.1.4 -> >=3.1.6
- python-multipart: >=0.0.9 -> >=0.0.20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

<!-- Brief description of changes (1-2 sentences) -->

## Related Issues

<!-- Link to related issues -->
Closes #
Related to #

## Type of Change

<!-- Check all that apply -->
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Test improvements

## Changes Made

<!-- Bullet list of specific changes -->
-
-
-

## How Has This Been Tested?

<!-- Describe testing performed -->

**Test Configuration:**
- Python version:
- PostgreSQL version:
- OS:

**Tests Added/Modified:**
- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests

## Acceptance Criteria Verification

<!-- If this PR addresses a user story, verify acceptance criteria -->

| Criterion | Verified |
|-----------|----------|
| | [ ] |
| | [ ] |

## Screenshots

<!-- If applicable, add screenshots or terminal output -->

## Checklist

<!-- Verify before requesting review -->

### Code Quality
- [ ] Code follows project style guidelines (`make lint` passes)
- [ ] Type hints added for all new functions
- [ ] No new warnings from `make typecheck`
- [ ] Self-review completed

### Testing
- [ ] Tests added for new functionality
- [ ] All tests pass (`make test`)
- [ ] Coverage not decreased

### Documentation
- [ ] Docstrings added/updated for public APIs
- [ ] README updated (if applicable)
- [ ] ADR created for architectural decisions (if applicable)

### Security
- [ ] No secrets or credentials in code
- [ ] No SQL injection vulnerabilities
- [ ] Input validation added where needed

## Additional Notes

<!-- Any additional context for reviewers -->
