### PR TITLE
fix(e2e): update run-demo.sh for FastAPI after migration

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,6 +1,6 @@
 # E2E Testing & Demo Application
 
-A Flask-based demo application for testing and demonstrating the commandbus library.
+A FastAPI-based demo application for testing and demonstrating the commandbus library.
 
 ## Quick Start
 

--- a/tests/e2e/app/config.py
+++ b/tests/e2e/app/config.py
@@ -10,14 +10,14 @@ load_dotenv()
 
 
 class Config:
-    """Flask configuration."""
+    """Application configuration."""
 
     SECRET_KEY = os.environ.get("SECRET_KEY", "dev-key-e2e-testing")
     DATABASE_URL = os.environ.get(
         "E2E_DATABASE_URL",
         "postgresql://postgres:postgres@localhost:5432/commandbus",  # pragma: allowlist secret
     )
-    DEBUG = os.environ.get("FLASK_DEBUG", "1") == "1"
+    DEBUG = os.environ.get("DEBUG", "1") == "1"
 
 
 @dataclass

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -1,7 +1,11 @@
 # E2E Demo Application Dependencies
-# Install with: pip install -r requirements.txt
+# Note: Use `uv sync --extra e2e` from project root instead.
+# This file is kept for reference only.
 
-Flask>=3.1.0
+fastapi>=0.128.0
+uvicorn[standard]>=0.40.0
+jinja2>=3.1.6
+python-multipart>=0.0.20
 python-dotenv>=1.0.1
 psycopg[binary,pool]>=3.2.0
 

--- a/tests/e2e/run-demo.sh
+++ b/tests/e2e/run-demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # E2E Demo Application Runner
-# This script sets up the environment and runs the Flask demo app
+# This script sets up the environment and runs the FastAPI demo app
 #
 # Recommended: Use 'make e2e-app' from the project root instead.
 #
@@ -45,8 +45,8 @@ cd "$PROJECT_ROOT"
 uv sync --extra e2e
 
 echo ""
-echo "Starting Flask demo app on http://localhost:${PORT:-5001}"
+echo "Starting FastAPI demo app on http://localhost:${PORT:-5001}"
 echo "Tip: Run 'make e2e-setup' if you see database errors."
 echo ""
 cd "$SCRIPT_DIR"
-exec uv run --project "$PROJECT_ROOT" --extra e2e python -m flask --app run:app run --host 0.0.0.0 --port "${PORT:-5001}"
+exec uv run --project "$PROJECT_ROOT" --extra e2e python run.py


### PR DESCRIPTION
## Summary
- Update run-demo.sh to use uvicorn/python run.py instead of flask command
- Update comments and messages from Flask to FastAPI
- Update requirements.txt to list FastAPI dependencies
- Update README.md and config.py references
- Replace `url_for('static')` with direct `/static/` paths in templates (Jinja2 templates can't resolve mounted StaticFiles routes via url_for)

## Test plan
- [x] Run `tests/e2e/run-demo.sh` to verify it starts the FastAPI app correctly
- [x] Verify HTTP 200 response from http://localhost:5001/

Fixes #89
Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)