### PR TITLE
fix(e2e): replace url_for('static') with direct /static/ paths

### DIFF
--- a/tests/e2e/app/templates/layouts/base.html
+++ b/tests/e2e/app/templates/layouts/base.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Command Bus E2E{% endblock %}</title>
-    <link href="{{ url_for('static', filename='dist/output.css') }}" rel="stylesheet">
+    <link href="/static/dist/output.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.css" rel="stylesheet" />
 </head>
 <body class="bg-gray-50 dark:bg-gray-900">
@@ -20,7 +20,7 @@
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.js"></script>
-    <script type="module" src="{{ url_for('static', filename='src/api.js') }}"></script>
+    <script type="module" src="/static/src/api.js"></script>
     {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/tests/e2e/app/templates/pages/audit.html
+++ b/tests/e2e/app/templates/pages/audit.html
@@ -122,7 +122,7 @@
 
 {% block scripts %}
 <script type="module">
-    import { ApiClient } from '{{ url_for("static", filename="src/api.js") }}';
+    import { ApiClient } from '/static/src/api.js';
 
     const api = new ApiClient();
 

--- a/tests/e2e/app/templates/pages/commands.html
+++ b/tests/e2e/app/templates/pages/commands.html
@@ -135,7 +135,7 @@
 
 {% block scripts %}
 <script type="module">
-    import { ApiClient } from '{{ url_for("static", filename="src/api.js") }}';
+    import { ApiClient } from '/static/src/api.js';
 
     const api = new ApiClient();
     let currentPage = 0;

--- a/tests/e2e/app/templates/pages/dashboard.html
+++ b/tests/e2e/app/templates/pages/dashboard.html
@@ -193,7 +193,7 @@
 
 {% block scripts %}
 <script type="module">
-    import { ApiClient } from '{{ url_for("static", filename="src/api.js") }}';
+    import { ApiClient } from '/static/src/api.js';
 
     const api = new ApiClient();
 

--- a/tests/e2e/app/templates/pages/send_command.html
+++ b/tests/e2e/app/templates/pages/send_command.html
@@ -126,7 +126,7 @@
 
 {% block scripts %}
 <script type="module">
-    import { ApiClient } from '{{ url_for("static", filename="src/api.js") }}';
+    import { ApiClient } from '/static/src/api.js';
 
     const api = new ApiClient();
     const behaviorType = document.getElementById('behavior-type');

--- a/tests/e2e/app/templates/pages/settings.html
+++ b/tests/e2e/app/templates/pages/settings.html
@@ -84,7 +84,7 @@
 
 {% block scripts %}
 <script type="module">
-    import { ApiClient } from '{{ url_for("static", filename="src/api.js") }}';
+    import { ApiClient } from '/static/src/api.js';
 
     const api = new ApiClient();
 

--- a/tests/e2e/app/templates/pages/tsq.html
+++ b/tests/e2e/app/templates/pages/tsq.html
@@ -156,7 +156,7 @@
 
 {% block scripts %}
 <script type="module">
-    import { ApiClient } from '{{ url_for("static", filename="src/api.js") }}';
+    import { ApiClient } from '/static/src/api.js';
 
     const api = new ApiClient();
     let commands = [];


### PR DESCRIPTION
## Summary
- Replace `url_for('static', filename='...')` with direct `/static/...` paths in all templates

## Root Cause
In FastAPI/Starlette, `app.mount()` creates a sub-application for StaticFiles. Routes in mounted sub-applications cannot be resolved via `url_for()` from the parent application's template context (unlike Flask which has built-in static file handling).

## Test plan
- [x] Run `tests/e2e/run-demo.sh` to verify the app starts and renders correctly
- [x] Verify HTTP 200 response from http://localhost:5001/

Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)