### PR TITLE
Fix E2E worker to use correct Worker and RetryPolicy API

### DIFF
--- a/tests/e2e/app/api/schemas.py
+++ b/tests/e2e/app/api/schemas.py
@@ -292,9 +292,7 @@ class RetryConfigSchema(BaseModel):
     """Retry configuration."""
 
     max_attempts: int = 3
-    base_delay_ms: int = 1000
-    max_delay_ms: int = 60000
-    backoff_multiplier: float = 2.0
+    backoff_schedule: list[int] = [10, 60, 300]
 
 
 class ConfigResponse(BaseModel):

--- a/tests/e2e/app/config.py
+++ b/tests/e2e/app/config.py
@@ -51,20 +51,21 @@ class WorkerConfig:
 
 @dataclass
 class RetryConfig:
-    """Retry configuration."""
+    """Retry configuration.
+
+    Uses backoff_schedule to match the commandbus RetryPolicy API.
+    Each value in backoff_schedule is the visibility timeout in seconds
+    for that retry attempt.
+    """
 
     max_attempts: int = 3
-    base_delay_ms: int = 1000
-    max_delay_ms: int = 60000
-    backoff_multiplier: float = 2.0
+    backoff_schedule: list[int] = field(default_factory=lambda: [10, 60, 300])
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
             "max_attempts": self.max_attempts,
-            "base_delay_ms": self.base_delay_ms,
-            "max_delay_ms": self.max_delay_ms,
-            "backoff_multiplier": self.backoff_multiplier,
+            "backoff_schedule": self.backoff_schedule,
         }
 
     @classmethod
@@ -72,9 +73,7 @@ class RetryConfig:
         """Create from dictionary."""
         return cls(
             max_attempts=data.get("max_attempts", 3),
-            base_delay_ms=data.get("base_delay_ms", 1000),
-            max_delay_ms=data.get("max_delay_ms", 60000),
-            backoff_multiplier=data.get("backoff_multiplier", 2.0),
+            backoff_schedule=data.get("backoff_schedule", [10, 60, 300]),
         )
 
 

--- a/tests/e2e/app/templates/pages/dashboard.html
+++ b/tests/e2e/app/templates/pages/dashboard.html
@@ -309,7 +309,7 @@
             document.getElementById('config-max-attempts').textContent = config.retry.max_attempts;
             document.getElementById('config-concurrency').textContent = config.worker.concurrency;
             document.getElementById('config-backoff').textContent =
-                `${config.retry.base_delay_ms/1000}s-${config.retry.max_delay_ms/1000}s (${config.retry.backoff_multiplier}x)`;
+                config.retry.backoff_schedule.join('s, ') + 's';
         }
     }
 

--- a/tests/e2e/app/templates/pages/send_command.html
+++ b/tests/e2e/app/templates/pages/send_command.html
@@ -150,7 +150,7 @@
             document.getElementById('config-visibility').textContent = config.worker.visibility_timeout + 's';
             document.getElementById('config-max-attempts').textContent = config.retry.max_attempts;
             document.getElementById('config-backoff').textContent =
-                `${config.retry.base_delay_ms/1000}s-${config.retry.max_delay_ms/1000}s (${config.retry.backoff_multiplier}x multiplier)`;
+                config.retry.backoff_schedule.join('s, ') + 's';
         }
     }
 

--- a/tests/e2e/app/templates/pages/settings.html
+++ b/tests/e2e/app/templates/pages/settings.html
@@ -54,21 +54,9 @@
             </div>
 
             <div>
-                <label for="base-delay" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Base Delay (ms)</label>
-                <input type="number" id="base-delay" min="100" max="60000" value="1000" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white">
-                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Base delay for exponential backoff</p>
-            </div>
-
-            <div>
-                <label for="max-delay" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Max Delay (ms)</label>
-                <input type="number" id="max-delay" min="1000" max="300000" value="60000" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white">
-                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Maximum delay between retries</p>
-            </div>
-
-            <div>
-                <label for="backoff-multiplier" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Backoff Multiplier</label>
-                <input type="number" id="backoff-multiplier" min="1" max="5" step="0.1" value="2.0" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white">
-                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Multiplier for exponential backoff</p>
+                <label for="backoff-schedule" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Backoff Schedule (seconds)</label>
+                <input type="text" id="backoff-schedule" value="10, 60, 300" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white">
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Comma-separated delays in seconds for each retry attempt</p>
             </div>
 
             <button type="submit" class="w-full px-5 py-2.5 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 focus:ring-4 focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
@@ -99,9 +87,7 @@
 
             // Retry settings
             document.getElementById('max-attempts').value = config.retry.max_attempts;
-            document.getElementById('base-delay').value = config.retry.base_delay_ms;
-            document.getElementById('max-delay').value = config.retry.max_delay_ms;
-            document.getElementById('backoff-multiplier').value = config.retry.backoff_multiplier;
+            document.getElementById('backoff-schedule').value = config.retry.backoff_schedule.join(', ');
         }
     }
 
@@ -131,12 +117,12 @@
 
     document.getElementById('retry-form').addEventListener('submit', async (e) => {
         e.preventDefault();
+        const scheduleStr = document.getElementById('backoff-schedule').value;
+        const schedule = scheduleStr.split(',').map(s => parseInt(s.trim())).filter(n => !isNaN(n));
         const data = {
             retry: {
                 max_attempts: parseInt(document.getElementById('max-attempts').value),
-                base_delay_ms: parseInt(document.getElementById('base-delay').value),
-                max_delay_ms: parseInt(document.getElementById('max-delay').value),
-                backoff_multiplier: parseFloat(document.getElementById('backoff-multiplier').value),
+                backoff_schedule: schedule,
             }
         };
         const result = await api.put('/config', data);


### PR DESCRIPTION
## Summary
- Fixed Worker constructor to use `registry` instead of `handler_registry`
- Changed Worker instantiation to pass `concurrency` and `poll_interval` to `run()` instead of constructor
- Updated RetryConfig to use `backoff_schedule` (list of seconds) instead of exponential backoff params (`base_delay_ms`, `max_delay_ms`, `multiplier`)
- Updated settings.html form and all related templates/schemas

## Test plan
- [x] Worker creates successfully without TypeError
- [x] Linting passes
- [ ] Run `run-demo.sh` and verify worker processes commands

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)