### PR TITLE
Fix TSQ list endpoint to call correct method

### DIFF
--- a/tests/e2e/app/api/routes.py
+++ b/tests/e2e/app/api/routes.py
@@ -580,7 +580,7 @@ async def list_tsq_commands(
     limit = min(limit, 100)
 
     try:
-        commands = await tsq.list_commands(E2E_DOMAIN, limit=limit, offset=offset)
+        commands = await tsq.list_troubleshooting(E2E_DOMAIN, limit=limit, offset=offset)
 
         result = [
             TSQCommandResponse(


### PR DESCRIPTION
## Summary
- Fixed `/tsq` endpoint which was calling non-existent `tsq.list_commands()` method
- Changed to `tsq.list_troubleshooting()` which is the actual method name

## Root Cause
The E2E API route was calling `tsq.list_commands()` but the `TroubleshootingQueue` class has a method called `list_troubleshooting()`, not `list_commands()`.

## Test plan
- [ ] Start demo app and worker
- [ ] Create a command with `fail_permanent` behavior
- [ ] Verify TSQ page now shows the command

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)