### PR TITLE
chore(e2e): stop existing workers before starting new one

### DIFF
--- a/tests/e2e/run-worker.sh
+++ b/tests/e2e/run-worker.sh
@@ -39,6 +39,15 @@ if ! docker compose -f "$PROJECT_ROOT/docker-compose.yml" ps postgres 2>/dev/nul
     echo ""
 fi
 
+# Stop any existing worker processes
+EXISTING_PIDS=$(pgrep -f "python -m app.worker" 2>/dev/null || true)
+if [ -n "$EXISTING_PIDS" ]; then
+    echo "Stopping existing worker processes..."
+    echo "$EXISTING_PIDS" | xargs kill 2>/dev/null || true
+    sleep 1
+    echo "Stopped."
+fi
+
 echo "Syncing dependencies with e2e extras..."
 cd "$PROJECT_ROOT"
 uv sync --extra e2e


### PR DESCRIPTION
## Summary
- Adds check to `run-worker.sh` that kills existing `app.worker` processes before starting
- Prevents old worker processes from running stale code

Fixes #104

## Test plan
- [ ] Run `./tests/e2e/run-worker.sh` when a worker is already running
- [ ] Verify old worker is stopped and new one starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)