### PR TITLE
fix(e2e): wrap dict params with Json() in config update endpoints

### DIFF
--- a/tests/e2e/app/api/routes.py
+++ b/tests/e2e/app/api/routes.py
@@ -9,6 +9,7 @@ from typing import Any
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, HTTPException
+from psycopg.types.json import Json
 
 from ..dependencies import TSQ, Bus, Pool
 from ..models import TestCommandRepository
@@ -564,7 +565,7 @@ async def update_config(request: ConfigUpdateRequest, pool: Pool) -> ConfigUpdat
                         VALUES ('worker', %s, NOW())
                         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
                     """,
-                    (request.worker.model_dump(),),
+                    (Json(request.worker.model_dump()),),
                 )
             if request.retry:
                 await cur.execute(
@@ -573,7 +574,7 @@ async def update_config(request: ConfigUpdateRequest, pool: Pool) -> ConfigUpdat
                         VALUES ('retry', %s, NOW())
                         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
                     """,
-                    (request.retry.model_dump(),),
+                    (Json(request.retry.model_dump()),),
                 )
 
         return ConfigUpdateResponse(status="ok", config=request)

--- a/tests/e2e/app/config.py
+++ b/tests/e2e/app/config.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from dotenv import load_dotenv
+from psycopg.types.json import Json
 
 load_dotenv()
 
@@ -104,7 +105,7 @@ class ConfigStore:
                     VALUES ('worker', %s, NOW())
                     ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
                     """,
-                (self._worker_config.to_dict(),),
+                (Json(self._worker_config.to_dict()),),
             )
             await cur.execute(
                 """
@@ -112,7 +113,7 @@ class ConfigStore:
                     VALUES ('retry', %s, NOW())
                     ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
                     """,
-                (self._retry_config.to_dict(),),
+                (Json(self._retry_config.to_dict()),),
             )
 
     @property


### PR DESCRIPTION
## Summary
- Fixes `psycopg.ProgrammingError: cannot adapt type 'dict'` error when saving config via Settings page
- psycopg3 requires explicit `Json()` wrapper for dict parameters when using `%s` placeholders
- Adds `Json()` wrapper in:
  - `routes.py update_config()`: worker and retry config params
  - `config.py save_to_db()`: worker and retry config params

Fixes #103

## Test plan
- [ ] Start E2E app with `make e2e-app`
- [ ] Go to Settings page
- [ ] Change any config value (e.g., concurrency)
- [ ] Click Save - verify no error occurs
- [ ] Refresh page and verify config was saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)