### PR TITLE
fix: trigger pg_notify when sending commands to PGMQ

### DIFF
--- a/src/commandbus/worker.py
+++ b/src/commandbus/worker.py
@@ -17,7 +17,7 @@ from commandbus.models import (
     HandlerContext,
     ReplyOutcome,
 )
-from commandbus.pgmq.client import PgmqClient
+from commandbus.pgmq.client import PGMQ_NOTIFY_CHANNEL, PgmqClient
 from commandbus.policies import DEFAULT_RETRY_POLICY, RetryPolicy
 from commandbus.repositories.audit import AuditEventType, PostgresAuditLogger
 from commandbus.repositories.command import PostgresCommandRepository
@@ -28,9 +28,6 @@ if TYPE_CHECKING:
     from commandbus.handler import HandlerRegistry
 
 logger = logging.getLogger(__name__)
-
-# Channel name for PGMQ notifications
-PGMQ_NOTIFY_CHANNEL = "pgmq_notify"
 
 
 def _make_queue_name(domain: str, suffix: str = "commands") -> str:


### PR DESCRIPTION
## Summary
- Fixes worker falling back to polling instead of receiving immediate notifications
- `PgmqClient._send()` now calls `NOTIFY pgmq_notify_{queue_name}` after enqueueing
- Workers with `use_notify=True` (the default) now wake up immediately when commands are sent

## Root Cause
The Worker was correctly listening on `pgmq_notify_{queue_name}` channel, but nothing was sending NOTIFY signals. Commands would sit in the queue until the next poll_interval (e.g., 10 seconds).

## Changes
- `src/commandbus/pgmq/client.py`: Add NOTIFY call after successful `pgmq.send()`
- `src/commandbus/worker.py`: Import `PGMQ_NOTIFY_CHANNEL` from client.py for consistency
- `tests/unit/test_pgmq_client.py`: Update tests to expect NOTIFY call

Fixes #108

## Test plan
- [x] All 208 unit tests pass
- [ ] Start E2E demo with worker
- [ ] Submit command and verify near-instant processing (<1 second vs previous 10 second delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)