### PR TITLE
fix: set autocommit on listen connection for pg_notify

### DIFF
--- a/src/commandbus/worker.py
+++ b/src/commandbus/worker.py
@@ -597,6 +597,10 @@ class Worker:
         assert self._stop_event is not None
 
         async with self._pool.connection() as listen_conn:
+            # Set autocommit mode - required for LISTEN/NOTIFY to work in real-time
+            # Without autocommit, notifications are only received when a transaction ends
+            await listen_conn.set_autocommit(True)
+
             # Subscribe to notifications for this queue
             channel = f"{PGMQ_NOTIFY_CHANNEL}_{self._queue_name}"
             await listen_conn.execute(f"LISTEN {channel}")


### PR DESCRIPTION
## Summary
Fixes pg_notify not working even after adding NOTIFY call in #109.

## Root Cause
psycopg3 requires the LISTEN connection to be in **autocommit mode** for notifications to be received in real-time. Without autocommit, notifications are buffered and only delivered when the connection's transaction ends - which never happens for a long-running listener.

## Fix
Added `await listen_conn.set_autocommit(True)` before calling `LISTEN`.

## Changes
- `src/commandbus/worker.py`: Set autocommit on the listen connection in `_run_with_notify()`

Fixes #108 (second fix needed after #109)

## Test plan
- [x] All 208 unit tests pass
- [ ] Start E2E demo with worker
- [ ] Submit command and verify near-instant processing (<100ms vs previous 10 second delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)