### PR TITLE
feat(e2e): add NoOp command handler for performance testing

### DIFF
--- a/tests/e2e/app/api/schemas.py
+++ b/tests/e2e/app/api/schemas.py
@@ -16,7 +16,7 @@ class CommandBehavior(BaseModel):
 
     type: str = Field(
         default="success",
-        description="Behavior type: success, fail_permanent, fail_transient, "
+        description="Behavior type: no_op, success, fail_permanent, fail_transient, "
         "fail_transient_then_succeed, timeout",
     )
     transient_failures: int = Field(

--- a/tests/e2e/app/handlers.py
+++ b/tests/e2e/app/handlers.py
@@ -11,6 +11,23 @@ from commandbus.exceptions import PermanentCommandError, TransientCommandError
 from .models import TestCommandRepository
 
 
+class NoOpHandlers:
+    """No-operation handlers for performance benchmarking.
+
+    These handlers do nothing except return immediately, allowing measurement
+    of raw command bus throughput without handler overhead.
+    """
+
+    def __init__(self, pool: AsyncConnectionPool) -> None:
+        """Initialize with database pool dependency (unused but required for consistency)."""
+        self._pool = pool
+
+    @handler(domain="e2e", command_type="NoOp")
+    async def handle_no_op(self, cmd: Command, ctx: HandlerContext) -> dict[str, Any]:
+        """Handle NoOp command - immediately returns success with no processing."""
+        return {"status": "success", "no_op": True}
+
+
 class TestCommandHandlers:
     """E2E test command handlers using @handler decorator.
 

--- a/tests/e2e/app/templates/pages/send_command.html
+++ b/tests/e2e/app/templates/pages/send_command.html
@@ -103,6 +103,7 @@
             <div>
                 <label for="bulk-behavior" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Behavior</label>
                 <select id="bulk-behavior" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white">
+                    <option value="no_op">No-Op (Performance Test)</option>
                     <option value="success">Success</option>
                     <option value="fail_permanent">Fail Permanent</option>
                     <option value="fail_transient">Fail Transient</option>

--- a/tests/e2e/app/worker.py
+++ b/tests/e2e/app/worker.py
@@ -8,7 +8,7 @@ from psycopg_pool import AsyncConnectionPool
 from commandbus import HandlerRegistry, RetryPolicy, Worker
 
 from .config import Config, ConfigStore, RetryConfig
-from .handlers import TestCommandHandlers
+from .handlers import NoOpHandlers, TestCommandHandlers
 
 logger = logging.getLogger(__name__)
 
@@ -38,12 +38,14 @@ def create_registry(pool: AsyncConnectionPool) -> HandlerRegistry:
     - @handler decorator on class methods
     - register_instance() for automatic handler discovery
     """
-    # Create handler instance with dependencies
-    handlers = TestCommandHandlers(pool)
+    # Create handler instances with dependencies
+    test_handlers = TestCommandHandlers(pool)
+    no_op_handlers = NoOpHandlers(pool)
 
     # Register all decorated handlers
     registry = HandlerRegistry()
-    registry.register_instance(handlers)
+    registry.register_instance(test_handlers)
+    registry.register_instance(no_op_handlers)
 
     return registry
 


### PR DESCRIPTION
## Summary
- Add `NoOpHandlers` class with empty `handle_no_op` method for pure throughput measurement
- Add "No-Op (Performance Test)" option to bulk generation UI dropdown
- Update API to use `NoOp` command type and skip test_command table for no-op requests

## Test plan
- [ ] Start e2e app and worker
- [ ] Create bulk NoOp commands from UI
- [ ] Verify commands complete with high throughput
- [ ] Verify no test_command table entries for NoOp commands

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)