### PR TITLE
docs: clarify rcmd stands for Reliable Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Command Bus
+# rcmd - Reliable Commands
 
 A Python library providing Command Bus abstraction over PostgreSQL + PGMQ.
 


### PR DESCRIPTION
## Summary
- Update README title to "rcmd - Reliable Commands"

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)