### PR TITLE
feat(batch): implement S041 create batch with commands (#125)

### DIFF
--- a/docs/features/F009-batch-commands.md
+++ b/docs/features/F009-batch-commands.md
@@ -1,0 +1,306 @@
+# F009: Batch Commands
+
+## Summary
+
+Enable applications to group multiple commands into a batch for coordinated tracking, providing aggregate status, counts, and completion callbacks.
+
+## Motivation
+
+Applications often need to send multiple related commands that logically belong together:
+- Bulk data imports processing items individually
+- Workflow steps that need coordinated completion tracking
+- Operations that require all-or-nothing visibility into success rates
+
+Without batch support, applications must implement their own tracking logic outside the command bus, leading to:
+- Duplicated coordination code
+- Race conditions in completion detection
+- Inconsistent status aggregation
+
+## User Stories
+
+- [S041](stories/S041-create-batch.md) - Create a batch with commands
+- [S042](stories/S042-batch-status-tracking.md) - Track batch status and counts
+- [S043](stories/S043-batch-completion-callback.md) - Receive callback on batch completion
+- [S044](stories/S044-query-batches.md) - Query batches and their commands
+
+## Acceptance Criteria (Feature-Level)
+
+- [ ] Batches are created atomically with all their commands in a single operation
+- [ ] Batch metadata is stored in `command_bus_batch` table
+- [ ] Commands reference their batch via `batch_id` foreign key
+- [ ] Batch counters (total, completed, failed, canceled, in_troubleshooting) are updated in real-time
+- [ ] Batch status transitions: PENDING → IN_PROGRESS → COMPLETED/COMPLETED_WITH_FAILURES
+- [ ] `started_at` is set when first command begins processing
+- [ ] `completed_at` is set when all commands reach terminal state
+- [ ] TSQ resolutions (operator complete/cancel) update batch counters
+- [ ] Audit events `BATCH_STARTED` and `BATCH_COMPLETED` are recorded
+- [ ] Optional async callback is invoked on batch completion
+- [ ] Referencing non-existent batch_id returns an error
+
+## Technical Design
+
+### Architecture
+
+```
+┌─────────────┐     ┌─────────────────────────────────────┐
+│ Application │────▶│    CommandBus.create_batch()        │
+└─────────────┘     └─────────────────────────────────────┘
+                                    │
+                    ┌───────────────┼───────────────┐
+                    ▼               ▼               ▼
+              ┌──────────┐   ┌──────────┐   ┌──────────┐
+              │  Batch   │   │ Commands │   │  Audit   │
+              │  Table   │   │  (PGMQ)  │   │  Table   │
+              └──────────┘   └──────────┘   └──────────┘
+                    │               │               │
+                    └───────────────┴───────────────┘
+                              Same Transaction
+```
+
+### Batch Lifecycle
+
+```
+                    ┌─────────┐
+                    │ PENDING │
+                    └────┬────┘
+                         │ First command starts (RECEIVED)
+                         ▼
+                   ┌───────────┐
+                   │IN_PROGRESS│
+                   └─────┬─────┘
+                         │ All commands reach terminal state
+           ┌─────────────┴─────────────┐
+           ▼                           ▼
+    ┌───────────┐            ┌─────────────────────┐
+    │ COMPLETED │            │COMPLETED_WITH_FAILURES│
+    └───────────┘            └─────────────────────┘
+    (all success)            (any failed/canceled)
+```
+
+### Dependencies
+
+- PostgreSQL 15+ with PGMQ extension
+- psycopg3 with connection pool
+- Existing CommandBus infrastructure
+
+### Data Changes
+
+#### New Table: `command_bus_batch`
+
+```sql
+CREATE TABLE command_bus_batch (
+    batch_id UUID PRIMARY KEY,
+    domain VARCHAR(255) NOT NULL,
+    name VARCHAR(255),
+    custom_data JSONB,
+    status VARCHAR(50) NOT NULL DEFAULT 'PENDING',
+    total_count INTEGER NOT NULL DEFAULT 0,
+    completed_count INTEGER NOT NULL DEFAULT 0,
+    failed_count INTEGER NOT NULL DEFAULT 0,
+    canceled_count INTEGER NOT NULL DEFAULT 0,
+    in_troubleshooting_count INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    CONSTRAINT valid_status CHECK (status IN ('PENDING', 'IN_PROGRESS', 'COMPLETED', 'COMPLETED_WITH_FAILURES'))
+);
+
+CREATE INDEX idx_batch_domain ON command_bus_batch(domain);
+CREATE INDEX idx_batch_status ON command_bus_batch(status);
+CREATE INDEX idx_batch_created_at ON command_bus_batch(created_at DESC);
+```
+
+#### Modification: `command_bus_command`
+
+```sql
+ALTER TABLE command_bus_command
+ADD COLUMN batch_id UUID REFERENCES command_bus_batch(batch_id);
+
+CREATE INDEX idx_command_batch_id ON command_bus_command(batch_id);
+```
+
+### API Changes
+
+```python
+from typing import Callable, Awaitable
+from dataclasses import dataclass
+
+@dataclass
+class BatchCommand:
+    """A command to be included in a batch."""
+    command_type: str
+    command_id: UUID
+    data: dict[str, Any]
+    reply_to: str | None = None
+    correlation_id: UUID | None = None
+
+@dataclass
+class BatchMetadata:
+    """Batch metadata returned from queries."""
+    batch_id: UUID
+    domain: str
+    name: str | None
+    custom_data: dict[str, Any] | None
+    status: str  # PENDING, IN_PROGRESS, COMPLETED, COMPLETED_WITH_FAILURES
+    total_count: int
+    completed_count: int
+    failed_count: int
+    canceled_count: int
+    in_troubleshooting_count: int
+    created_at: datetime
+    started_at: datetime | None
+    completed_at: datetime | None
+
+# Callback type
+BatchCompletionCallback = Callable[[BatchMetadata], Awaitable[None]]
+
+class CommandBus:
+    async def create_batch(
+        self,
+        domain: str,
+        commands: list[BatchCommand],
+        *,
+        name: str | None = None,
+        custom_data: dict[str, Any] | None = None,
+        on_complete: BatchCompletionCallback | None = None,
+    ) -> UUID:
+        """Create a batch with all commands atomically.
+
+        Args:
+            domain: The domain for all commands in the batch
+            commands: List of commands to include (must have at least 1)
+            name: Optional human-readable batch name
+            custom_data: Optional custom metadata for the batch
+            on_complete: Optional async callback invoked when batch completes
+
+        Returns:
+            The batch_id
+
+        Raises:
+            ValueError: If commands list is empty
+        """
+
+    async def get_batch(
+        self,
+        domain: str,
+        batch_id: UUID,
+    ) -> BatchMetadata | None:
+        """Get batch metadata by ID."""
+
+    async def list_batches(
+        self,
+        domain: str,
+        *,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[BatchMetadata]:
+        """List batches for a domain."""
+
+    async def list_batch_commands(
+        self,
+        domain: str,
+        batch_id: UUID,
+        *,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[CommandMetadata]:
+        """List commands in a batch."""
+```
+
+### Counter Update Logic
+
+Counters are updated by database triggers or stored procedures when:
+
+1. **Command RECEIVED** (first processing):
+   - If batch `status = PENDING`, set `status = IN_PROGRESS`, `started_at = NOW()`
+   - Record `BATCH_STARTED` audit event
+
+2. **Command COMPLETED**:
+   - Increment `completed_count`
+   - Check for batch completion
+
+3. **Command moved to TSQ** (permanent failure or exhaustion):
+   - Increment `in_troubleshooting_count`
+
+4. **TSQ Operator Complete**:
+   - Decrement `in_troubleshooting_count`
+   - Increment `completed_count`
+   - Check for batch completion
+
+5. **TSQ Operator Cancel**:
+   - Decrement `in_troubleshooting_count`
+   - Increment `canceled_count`
+   - Check for batch completion
+
+6. **Batch Completion Check**:
+   - If `completed_count + failed_count + canceled_count = total_count`:
+     - Set `completed_at = NOW()`
+     - If `failed_count + canceled_count > 0`: set `status = COMPLETED_WITH_FAILURES`
+     - Else: set `status = COMPLETED`
+     - Record `BATCH_COMPLETED` audit event
+     - Invoke `on_complete` callback (if registered)
+
+### Callback Registry
+
+```python
+# In-memory registry for batch completion callbacks
+# Key: (domain, batch_id), Value: callback function
+_batch_callbacks: dict[tuple[str, UUID], BatchCompletionCallback] = {}
+```
+
+Callbacks are registered during `create_batch()` and invoked by the worker when detecting batch completion.
+
+## Out of Scope
+
+- Batch cancellation (cancelling all pending commands)
+- Adding commands to existing batch after creation
+- Cross-domain batches
+- Batch priority
+- Batch TTL/expiration
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Counter race conditions | Medium | Use database-level atomic updates (triggers/stored procedures) |
+| Callback registry lost on restart | Medium | Callbacks are best-effort; applications should poll for completion |
+| Large batches causing transaction timeouts | Medium | Document size limits, consider chunked creation |
+| Orphaned batches (never complete) | Low | No auto-cleanup; applications monitor via queries |
+
+## Implementation Milestones
+
+- [ ] Milestone 1: Database schema and batch creation
+- [ ] Milestone 2: Counter updates via triggers/stored procedures
+- [ ] Milestone 3: Query APIs (get_batch, list_batches, list_batch_commands)
+- [ ] Milestone 4: Batch audit events (BATCH_STARTED, BATCH_COMPLETED)
+- [ ] Milestone 5: Completion callback mechanism
+- [ ] Milestone 6: Integration with TSQ operations
+
+## LLM Agent Notes
+
+**Reference Files:**
+- `src/commandbus/bus.py` - CommandBus class (add batch methods)
+- `src/commandbus/models.py` - Add BatchMetadata, BatchCommand dataclasses
+- `src/commandbus/repositories/` - Add batch repository
+- `scripts/init-db.sql` - Add batch table and triggers
+- `src/commandbus/worker.py` - Trigger batch events on command state changes
+
+**Patterns to Follow:**
+- Use `async with conn.transaction()` for atomic batch creation
+- Repository pattern for batch database access
+- Existing audit event patterns for BATCH_STARTED/BATCH_COMPLETED
+- Command audit events should include batch_id when present
+
+**Constraints:**
+- Batch creation must be atomic (all commands or none)
+- Counter updates must be atomic (use DB triggers/procedures)
+- Callbacks are in-memory only (not persisted)
+- All commands in a batch belong to the same domain
+
+**Verification Steps:**
+1. `make test-unit` - Unit tests pass
+2. `make test-integration` - Integration tests pass
+3. `make typecheck` - No type errors
+4. Create batch, process commands, verify counters and status transitions

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -18,6 +18,7 @@ See [development-plan.md](development-plan.md) for the implementation sequence a
 | [F006](F006-e2e-testing-demo.md) | E2E Testing & Demo App | Should Have | Complete |
 | [F007](F007-handler-dependency-injection.md) | Handler DI & Transactions | Should Have | Planned |
 | [F008](F008-e2e-fastapi-migration.md) | E2E FastAPI Migration | Should Have | Planned |
+| [F009](F009-batch-commands.md) | Batch Commands | Should Have | Planned |
 
 ## User Story Index
 
@@ -78,6 +79,12 @@ Stories are organized by parent feature. Each story follows INVEST criteria and 
 - S038 - Web Routes with Jinja2
 - S039 - OpenAPI Documentation Review
 - S040 - Handler Classes with @handler Decorator (uses F007)
+
+### F009 - Batch Commands
+- [S041](stories/S041-create-batch.md) - Create a batch with commands
+- [S042](stories/S042-batch-status-tracking.md) - Track batch status and counts
+- [S043](stories/S043-batch-completion-callback.md) - Receive callback on batch completion
+- [S044](stories/S044-query-batches.md) - Query batches and their commands
 
 ## Document Format
 

--- a/docs/features/stories/S041-create-batch.md
+++ b/docs/features/stories/S041-create-batch.md
@@ -1,0 +1,140 @@
+# S041: Create a Batch with Commands
+
+## Parent Feature
+
+[F009 - Batch Commands](../F009-batch-commands.md)
+
+## User Story
+
+**As a** application developer
+**I want** to create a batch containing multiple commands atomically
+**So that** I can track their collective progress and completion
+
+## Context
+
+Batches group related commands for coordinated tracking. All commands in a batch are created together in a single transaction, ensuring either all commands are queued or none are. The batch is "closed" immediately - no new commands can be added after creation.
+
+## Acceptance Criteria (Given-When-Then)
+
+### Scenario: Create a batch with multiple commands
+
+**Given** the Command Bus is connected to PostgreSQL with PGMQ
+**And** the domain queue "payments__commands" exists
+**When** I create a batch with:
+  - domain: "payments"
+  - name: "Monthly billing run"
+  - commands: [
+      {command_type: "DebitAccount", command_id: UUID1, data: {...}},
+      {command_type: "DebitAccount", command_id: UUID2, data: {...}},
+      {command_type: "DebitAccount", command_id: UUID3, data: {...}}
+    ]
+**Then** a batch_id is returned
+**And** a row is inserted into `command_bus_batch` with:
+  - status: "PENDING"
+  - total_count: 3
+  - completed_count: 0
+  - failed_count: 0
+  - canceled_count: 0
+  - in_troubleshooting_count: 0
+**And** three rows are inserted into `command_bus_command` with batch_id set
+**And** three messages are sent to the PGMQ queue "payments__commands"
+**And** audit events "SENT" are recorded for each command (with batch_id in metadata)
+
+### Scenario: Create a batch with custom metadata
+
+**Given** the Command Bus is connected
+**When** I create a batch with:
+  - name: "Import job 12345"
+  - custom_data: {"source": "csv", "file_id": "abc123"}
+**Then** the name and custom_data are stored in `command_bus_batch`
+
+### Scenario: Create a batch with completion callback
+
+**Given** the Command Bus is connected
+**And** I define an async callback function
+**When** I create a batch with on_complete: my_callback
+**Then** the callback is registered in memory for this batch
+**And** the batch_id is returned
+
+### Scenario: Attempt to create empty batch
+
+**Given** the Command Bus is connected
+**When** I create a batch with commands: []
+**Then** a ValueError is raised with message "Batch must contain at least one command"
+
+### Scenario: Duplicate command_id in batch
+
+**Given** the Command Bus is connected
+**When** I create a batch with two commands having the same command_id
+**Then** a DuplicateCommandError is raised
+**And** no batch or commands are created (transaction rolled back)
+
+### Scenario: Atomic failure
+
+**Given** the Command Bus is connected
+**And** command_id UUID2 already exists in the database
+**When** I create a batch with commands including UUID2
+**Then** a DuplicateCommandError is raised
+**And** no batch is created
+**And** no other commands from the batch are created
+
+## Test Mapping
+
+| Criterion | Test Type | Test Location |
+|-----------|-----------|---------------|
+| Batch created with commands | Unit | `tests/unit/test_batch.py::test_create_batch_stores_batch_and_commands` |
+| Total count set correctly | Unit | `tests/unit/test_batch.py::test_create_batch_sets_total_count` |
+| Commands have batch_id | Unit | `tests/unit/test_batch.py::test_create_batch_links_commands` |
+| Empty batch rejected | Unit | `tests/unit/test_batch.py::test_create_batch_rejects_empty` |
+| Callback registered | Unit | `tests/unit/test_batch.py::test_create_batch_registers_callback` |
+| Full creation flow | Integration | `tests/integration/test_batch.py::test_create_batch_atomic` |
+| Duplicate handling | Integration | `tests/integration/test_batch.py::test_create_batch_duplicate_rollback` |
+
+## Story Size
+
+M (2000-4000 tokens, medium feature)
+
+## Priority (MoSCoW)
+
+Must Have
+
+## Dependencies
+
+- PostgreSQL with PGMQ extension running
+- Database schema with `command_bus_batch` table
+- Existing CommandBus.send() infrastructure
+
+## Technical Notes
+
+- Use `async with conn.transaction()` to ensure atomicity
+- Generate batch_id as UUID if not provided
+- All commands inherit the batch's domain
+- Callback registry is in-memory only (lost on restart)
+
+## LLM Agent Instructions
+
+**Reference Files:**
+- `src/commandbus/bus.py` - Add create_batch() method
+- `src/commandbus/models.py` - Add BatchCommand, BatchMetadata dataclasses
+- `src/commandbus/repositories/batch.py` - New batch repository (create)
+- `scripts/init-db.sql` - Add batch table schema
+
+**Constraints:**
+- All operations in single transaction
+- Use parameterized queries
+- Validate commands list is non-empty
+- Handle duplicate command_id within batch and against existing commands
+
+**Verification Steps:**
+1. Run `pytest tests/unit/test_batch.py -v`
+2. Run `pytest tests/integration/test_batch.py -v`
+3. Run `make typecheck`
+
+## Definition of Done
+
+- [ ] Code complete and reviewed
+- [ ] Unit tests written and passing
+- [ ] Integration tests written and passing
+- [ ] Acceptance criteria verified
+- [ ] Documentation updated (if applicable)
+- [ ] No regressions in related functionality

--- a/src/commandbus/__init__.py
+++ b/src/commandbus/__init__.py
@@ -2,6 +2,7 @@
 
 from commandbus.bus import CommandBus
 from commandbus.exceptions import (
+    BatchNotFoundError,
     CommandBusError,
     CommandNotFoundError,
     DuplicateCommandError,
@@ -14,10 +15,14 @@ from commandbus.exceptions import (
 from commandbus.handler import HandlerMeta, HandlerRegistry, handler
 from commandbus.models import (
     AuditEvent,
+    BatchCommand,
+    BatchMetadata,
     BatchSendResult,
+    BatchStatus,
     Command,
     CommandMetadata,
     CommandStatus,
+    CreateBatchResult,
     HandlerContext,
     ReplyOutcome,
     SendRequest,
@@ -28,6 +33,7 @@ from commandbus.ops.troubleshooting import TroubleshootingQueue
 from commandbus.pgmq.client import PgmqClient, PgmqMessage
 from commandbus.policies import DEFAULT_RETRY_POLICY, RetryPolicy
 from commandbus.repositories.audit import AuditEventType, PostgresAuditLogger
+from commandbus.repositories.batch import PostgresBatchRepository
 from commandbus.repositories.command import PostgresCommandRepository
 from commandbus.worker import ReceivedCommand, Worker
 
@@ -35,13 +41,18 @@ __all__ = [
     "DEFAULT_RETRY_POLICY",
     "AuditEvent",
     "AuditEventType",
+    "BatchCommand",
+    "BatchMetadata",
+    "BatchNotFoundError",
     "BatchSendResult",
+    "BatchStatus",
     "Command",
     "CommandBus",
     "CommandBusError",
     "CommandMetadata",
     "CommandNotFoundError",
     "CommandStatus",
+    "CreateBatchResult",
     "DuplicateCommandError",
     "HandlerAlreadyRegisteredError",
     "HandlerContext",
@@ -53,6 +64,7 @@ __all__ = [
     "PgmqClient",
     "PgmqMessage",
     "PostgresAuditLogger",
+    "PostgresBatchRepository",
     "PostgresCommandRepository",
     "ReceivedCommand",
     "ReplyOutcome",

--- a/src/commandbus/exceptions.py
+++ b/src/commandbus/exceptions.py
@@ -78,3 +78,12 @@ class InvalidOperationError(CommandBusError):
 
     def __init__(self, message: str) -> None:
         super().__init__(message)
+
+
+class BatchNotFoundError(CommandBusError):
+    """Raised when a batch does not exist."""
+
+    def __init__(self, domain: str, batch_id: str) -> None:
+        self.domain = domain
+        self.batch_id = batch_id
+        super().__init__(f"Batch {batch_id} not found in domain {domain}")

--- a/src/commandbus/repositories/batch.py
+++ b/src/commandbus/repositories/batch.py
@@ -1,0 +1,257 @@
+"""Repository for batch metadata storage."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from commandbus.models import BatchMetadata, BatchStatus
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from psycopg import AsyncConnection
+    from psycopg_pool import AsyncConnectionPool
+
+logger = logging.getLogger(__name__)
+
+
+class PostgresBatchRepository:
+    """PostgreSQL implementation of batch repository."""
+
+    def __init__(self, pool: AsyncConnectionPool[Any]) -> None:
+        """Initialize the repository.
+
+        Args:
+            pool: psycopg async connection pool
+        """
+        self._pool = pool
+
+    async def save(
+        self,
+        metadata: BatchMetadata,
+        conn: AsyncConnection[Any] | None = None,
+    ) -> None:
+        """Save batch metadata to the database.
+
+        Args:
+            metadata: Batch metadata to save
+            conn: Optional connection (for transaction support)
+        """
+        if conn is not None:
+            await self._save(conn, metadata)
+        else:
+            async with self._pool.connection() as acquired_conn:
+                await self._save(acquired_conn, metadata)
+
+    async def _save(
+        self,
+        conn: AsyncConnection[Any],
+        metadata: BatchMetadata,
+    ) -> None:
+        """Save metadata using an existing connection."""
+        custom_data_json = json.dumps(metadata.custom_data) if metadata.custom_data else None
+        await conn.execute(
+            """
+            INSERT INTO command_bus_batch (
+                domain, batch_id, name, custom_data, status,
+                total_count, completed_count, failed_count,
+                canceled_count, in_troubleshooting_count,
+                created_at, started_at, completed_at
+            ) VALUES (%s, %s, %s, %s::jsonb, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                metadata.domain,
+                metadata.batch_id,
+                metadata.name,
+                custom_data_json,
+                metadata.status.value,
+                metadata.total_count,
+                metadata.completed_count,
+                metadata.failed_count,
+                metadata.canceled_count,
+                metadata.in_troubleshooting_count,
+                metadata.created_at,
+                metadata.started_at,
+                metadata.completed_at,
+            ),
+        )
+        logger.debug(f"Saved batch metadata: {metadata.domain}.{metadata.batch_id}")
+
+    async def get(
+        self,
+        domain: str,
+        batch_id: UUID,
+        conn: AsyncConnection[Any] | None = None,
+    ) -> BatchMetadata | None:
+        """Get batch metadata by domain and batch_id.
+
+        Args:
+            domain: The domain
+            batch_id: The batch ID
+            conn: Optional connection (for transaction support)
+
+        Returns:
+            BatchMetadata if found, None otherwise
+        """
+        if conn is not None:
+            return await self._get(conn, domain, batch_id)
+
+        async with self._pool.connection() as acquired_conn:
+            return await self._get(acquired_conn, domain, batch_id)
+
+    async def _get(
+        self,
+        conn: AsyncConnection[Any],
+        domain: str,
+        batch_id: UUID,
+    ) -> BatchMetadata | None:
+        """Get metadata using an existing connection."""
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                SELECT domain, batch_id, name, custom_data, status,
+                       total_count, completed_count, failed_count,
+                       canceled_count, in_troubleshooting_count,
+                       created_at, started_at, completed_at
+                FROM command_bus_batch
+                WHERE domain = %s AND batch_id = %s
+                """,
+                (domain, batch_id),
+            )
+            row = await cur.fetchone()
+
+        if row is None:
+            return None
+
+        return self._row_to_metadata(row)
+
+    async def exists(
+        self,
+        domain: str,
+        batch_id: UUID,
+        conn: AsyncConnection[Any] | None = None,
+    ) -> bool:
+        """Check if a batch exists.
+
+        Args:
+            domain: The domain
+            batch_id: The batch ID
+            conn: Optional connection (for transaction support)
+
+        Returns:
+            True if batch exists, False otherwise
+        """
+        if conn is not None:
+            return await self._exists(conn, domain, batch_id)
+
+        async with self._pool.connection() as acquired_conn:
+            return await self._exists(acquired_conn, domain, batch_id)
+
+    async def _exists(
+        self,
+        conn: AsyncConnection[Any],
+        domain: str,
+        batch_id: UUID,
+    ) -> bool:
+        """Check existence using an existing connection."""
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                SELECT EXISTS(
+                    SELECT 1 FROM command_bus_batch
+                    WHERE domain = %s AND batch_id = %s
+                )
+                """,
+                (domain, batch_id),
+            )
+            row = await cur.fetchone()
+            return bool(row[0]) if row else False
+
+    async def list_batches(
+        self,
+        domain: str,
+        *,
+        status: BatchStatus | str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        conn: AsyncConnection[Any] | None = None,
+    ) -> list[BatchMetadata]:
+        """List batches for a domain.
+
+        Args:
+            domain: The domain to list batches for
+            status: Optional status filter
+            limit: Maximum number of batches to return (default 100)
+            offset: Number of batches to skip (default 0)
+            conn: Optional connection (for transaction support)
+
+        Returns:
+            List of BatchMetadata ordered by created_at descending
+        """
+        if conn is not None:
+            return await self._list_batches(conn, domain, status, limit, offset)
+
+        async with self._pool.connection() as acquired_conn:
+            return await self._list_batches(acquired_conn, domain, status, limit, offset)
+
+    async def _list_batches(
+        self,
+        conn: AsyncConnection[Any],
+        domain: str,
+        status: BatchStatus | str | None,
+        limit: int,
+        offset: int,
+    ) -> list[BatchMetadata]:
+        """List batches using an existing connection."""
+        conditions = ["domain = %s"]
+        params: list[Any] = [domain]
+
+        if status is not None:
+            status_value = status.value if isinstance(status, BatchStatus) else status
+            conditions.append("status = %s")
+            params.append(status_value)
+
+        where_clause = " AND ".join(conditions)
+        params.extend([limit, offset])
+
+        async with conn.cursor() as cur:
+            await cur.execute(
+                f"""
+                SELECT domain, batch_id, name, custom_data, status,
+                       total_count, completed_count, failed_count,
+                       canceled_count, in_troubleshooting_count,
+                       created_at, started_at, completed_at
+                FROM command_bus_batch
+                WHERE {where_clause}
+                ORDER BY created_at DESC
+                LIMIT %s OFFSET %s
+                """,
+                tuple(params),
+            )
+            rows = await cur.fetchall()
+
+        return [self._row_to_metadata(row) for row in rows]
+
+    def _row_to_metadata(self, row: tuple[Any, ...]) -> BatchMetadata:
+        """Convert a database row to BatchMetadata."""
+        custom_data = row[3]
+        if isinstance(custom_data, str):
+            custom_data = json.loads(custom_data)
+
+        return BatchMetadata(
+            domain=row[0],
+            batch_id=row[1],
+            name=row[2],
+            custom_data=custom_data,
+            status=BatchStatus(row[4]),
+            total_count=row[5],
+            completed_count=row[6],
+            failed_count=row[7],
+            canceled_count=row[8],
+            in_troubleshooting_count=row[9],
+            created_at=row[10],
+            started_at=row[11],
+            completed_at=row[12],
+        )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -95,9 +95,10 @@ async def cleanup_payments_domain(pool: AsyncConnectionPool) -> AsyncGenerator[N
         await conn.execute("SELECT pgmq.create('payments__replies')")
         await conn.execute("SELECT pgmq.create('reports__replies')")
 
-        # Clean up before test
+        # Clean up before test (commands must be deleted before batches due to FK)
         await conn.execute("DELETE FROM command_bus_audit WHERE domain = 'payments'")
         await conn.execute("DELETE FROM command_bus_command WHERE domain = 'payments'")
+        await conn.execute("DELETE FROM command_bus_batch WHERE domain = 'payments'")
         await conn.execute("DELETE FROM pgmq.q_payments__commands")
         await conn.execute("DELETE FROM pgmq.q_payments__replies")
         await conn.execute("DELETE FROM pgmq.q_reports__replies")
@@ -108,6 +109,7 @@ async def cleanup_payments_domain(pool: AsyncConnectionPool) -> AsyncGenerator[N
     async with pool.connection() as conn:
         await conn.execute("DELETE FROM command_bus_audit WHERE domain = 'payments'")
         await conn.execute("DELETE FROM command_bus_command WHERE domain = 'payments'")
+        await conn.execute("DELETE FROM command_bus_batch WHERE domain = 'payments'")
         await conn.execute("DELETE FROM pgmq.q_payments__commands")
         await conn.execute("DELETE FROM pgmq.q_payments__replies")
         await conn.execute("DELETE FROM pgmq.q_reports__replies")

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -1,0 +1,420 @@
+"""Integration tests for batch creation functionality."""
+
+from uuid import uuid4
+
+import pytest
+from psycopg_pool import AsyncConnectionPool
+
+from commandbus import (
+    BatchCommand,
+    BatchStatus,
+    CommandBus,
+    CommandStatus,
+    DuplicateCommandError,
+)
+
+
+@pytest.mark.asyncio
+class TestCreateBatchAtomic:
+    """Integration tests for atomic batch creation."""
+
+    async def test_create_batch_stores_batch_and_commands(
+        self,
+        command_bus: CommandBus,
+        pool: AsyncConnectionPool,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test that batch and all commands are stored atomically."""
+        batch_id = uuid4()
+        cmd1_id = uuid4()
+        cmd2_id = uuid4()
+        cmd3_id = uuid4()
+
+        result = await command_bus.create_batch(
+            domain="payments",
+            commands=[
+                BatchCommand(
+                    command_type="DebitAccount",
+                    command_id=cmd1_id,
+                    data={"account_id": "123", "amount": 100},
+                ),
+                BatchCommand(
+                    command_type="DebitAccount",
+                    command_id=cmd2_id,
+                    data={"account_id": "456", "amount": 200},
+                ),
+                BatchCommand(
+                    command_type="CreditAccount",
+                    command_id=cmd3_id,
+                    data={"account_id": "789", "amount": 300},
+                ),
+            ],
+            batch_id=batch_id,
+            name="Monthly billing run",
+        )
+
+        assert result.batch_id == batch_id
+        assert result.total_commands == 3
+        assert len(result.command_results) == 3
+
+        # Verify batch is in database
+        batch = await command_bus.get_batch("payments", batch_id)
+        assert batch is not None
+        assert batch.batch_id == batch_id
+        assert batch.domain == "payments"
+        assert batch.name == "Monthly billing run"
+        assert batch.status == BatchStatus.PENDING
+        assert batch.total_count == 3
+        assert batch.completed_count == 0
+        assert batch.failed_count == 0
+        assert batch.canceled_count == 0
+        assert batch.in_troubleshooting_count == 0
+
+        # Verify commands are in database with batch_id set
+        for cmd_id in [cmd1_id, cmd2_id, cmd3_id]:
+            cmd = await command_bus.get_command("payments", cmd_id)
+            assert cmd is not None
+            assert cmd.batch_id == batch_id
+            assert cmd.status == CommandStatus.PENDING
+
+    async def test_create_batch_with_custom_data(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test that custom metadata is stored correctly."""
+        batch_id = uuid4()
+        custom = {"source": "csv", "file_id": "abc123", "row_count": 100}
+
+        await command_bus.create_batch(
+            domain="payments",
+            commands=[
+                BatchCommand(
+                    command_type="DebitAccount",
+                    command_id=uuid4(),
+                    data={"account_id": "123"},
+                ),
+            ],
+            batch_id=batch_id,
+            name="Import job 12345",
+            custom_data=custom,
+        )
+
+        batch = await command_bus.get_batch("payments", batch_id)
+        assert batch is not None
+        assert batch.name == "Import job 12345"
+        assert batch.custom_data == custom
+
+    async def test_create_batch_generates_batch_id(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test that batch_id is auto-generated if not provided."""
+        result = await command_bus.create_batch(
+            domain="payments",
+            commands=[
+                BatchCommand(
+                    command_type="DebitAccount",
+                    command_id=uuid4(),
+                    data={},
+                ),
+            ],
+        )
+
+        assert result.batch_id is not None
+        batch = await command_bus.get_batch("payments", result.batch_id)
+        assert batch is not None
+
+    async def test_create_batch_messages_queued(
+        self,
+        command_bus: CommandBus,
+        pool: AsyncConnectionPool,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test that messages are queued in PGMQ."""
+        result = await command_bus.create_batch(
+            domain="payments",
+            commands=[
+                BatchCommand(
+                    command_type="DebitAccount",
+                    command_id=uuid4(),
+                    data={"account_id": "123"},
+                )
+                for _ in range(3)
+            ],
+        )
+
+        assert result.total_commands == 3
+
+        # Check messages are in PGMQ queue
+        async with pool.connection() as conn, conn.cursor() as cur:
+            await cur.execute("SELECT COUNT(*) FROM pgmq.q_payments__commands")
+            row = await cur.fetchone()
+            assert row is not None
+            assert row[0] == 3
+
+    async def test_create_batch_audit_events(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test that SENT audit events are recorded with batch_id."""
+        batch_id = uuid4()
+        cmd_id = uuid4()
+
+        await command_bus.create_batch(
+            domain="payments",
+            commands=[
+                BatchCommand(
+                    command_type="DebitAccount",
+                    command_id=cmd_id,
+                    data={},
+                ),
+            ],
+            batch_id=batch_id,
+        )
+
+        events = await command_bus.get_audit_trail(cmd_id)
+        assert len(events) == 1
+        assert events[0].event_type == "SENT"
+        assert events[0].details is not None
+        assert events[0].details.get("batch_id") == str(batch_id)
+
+
+@pytest.mark.asyncio
+class TestCreateBatchDuplicateRollback:
+    """Tests for atomicity - rollback on duplicate."""
+
+    async def test_duplicate_command_id_in_batch_rollback(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test that duplicate command_id in batch causes rollback."""
+        cmd_id = uuid4()
+
+        with pytest.raises(DuplicateCommandError):
+            await command_bus.create_batch(
+                domain="payments",
+                commands=[
+                    BatchCommand(
+                        command_type="DebitAccount",
+                        command_id=cmd_id,
+                        data={},
+                    ),
+                    BatchCommand(
+                        command_type="DebitAccount",
+                        command_id=cmd_id,  # duplicate
+                        data={},
+                    ),
+                ],
+            )
+
+    async def test_duplicate_existing_command_rollback(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test that duplicate against existing command causes rollback."""
+        existing_id = uuid4()
+        batch_id = uuid4()
+
+        # Create a command first
+        await command_bus.send(
+            domain="payments",
+            command_type="DebitAccount",
+            command_id=existing_id,
+            data={},
+        )
+
+        # Try to create batch with that command ID
+        with pytest.raises(DuplicateCommandError):
+            await command_bus.create_batch(
+                domain="payments",
+                commands=[
+                    BatchCommand(
+                        command_type="DebitAccount",
+                        command_id=uuid4(),
+                        data={},
+                    ),
+                    BatchCommand(
+                        command_type="DebitAccount",
+                        command_id=existing_id,  # exists in DB
+                        data={},
+                    ),
+                ],
+                batch_id=batch_id,
+            )
+
+        # Batch should not exist
+        batch = await command_bus.get_batch("payments", batch_id)
+        assert batch is None
+
+
+@pytest.mark.asyncio
+class TestBatchGetAndList:
+    """Tests for batch retrieval operations."""
+
+    async def test_get_batch_returns_metadata(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test that get_batch returns full metadata."""
+        batch_id = uuid4()
+        custom = {"key": "value"}
+
+        await command_bus.create_batch(
+            domain="payments",
+            commands=[
+                BatchCommand(
+                    command_type="Cmd",
+                    command_id=uuid4(),
+                    data={},
+                )
+                for _ in range(5)
+            ],
+            batch_id=batch_id,
+            name="Test Batch",
+            custom_data=custom,
+        )
+
+        batch = await command_bus.get_batch("payments", batch_id)
+        assert batch is not None
+        assert batch.batch_id == batch_id
+        assert batch.domain == "payments"
+        assert batch.name == "Test Batch"
+        assert batch.custom_data == custom
+        assert batch.status == BatchStatus.PENDING
+        assert batch.total_count == 5
+        assert batch.created_at is not None
+
+    async def test_get_batch_returns_none_for_nonexistent(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test that get_batch returns None for non-existent batch."""
+        batch = await command_bus.get_batch("payments", uuid4())
+        assert batch is None
+
+    async def test_get_batch_domain_scoped(
+        self,
+        command_bus: CommandBus,
+        pool: AsyncConnectionPool,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test that get_batch is domain-scoped."""
+        batch_id = uuid4()
+
+        # Create queue for orders domain
+        async with pool.connection() as conn:
+            await conn.execute("SELECT pgmq.create('orders__commands')")
+            await conn.execute("SELECT pgmq.create('orders__replies')")
+
+        await command_bus.create_batch(
+            domain="payments",
+            commands=[
+                BatchCommand(
+                    command_type="Cmd",
+                    command_id=uuid4(),
+                    data={},
+                ),
+            ],
+            batch_id=batch_id,
+        )
+
+        # Same batch_id but different domain should return None
+        batch = await command_bus.get_batch("orders", batch_id)
+        assert batch is None
+
+        # Correct domain should return batch
+        batch = await command_bus.get_batch("payments", batch_id)
+        assert batch is not None
+
+
+@pytest.mark.asyncio
+class TestBatchCommandMetadata:
+    """Tests for command metadata in batches."""
+
+    async def test_command_has_batch_id(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test that commands in batch have batch_id set."""
+        batch_id = uuid4()
+        cmd_id = uuid4()
+
+        await command_bus.create_batch(
+            domain="payments",
+            commands=[
+                BatchCommand(
+                    command_type="DebitAccount",
+                    command_id=cmd_id,
+                    data={},
+                ),
+            ],
+            batch_id=batch_id,
+        )
+
+        cmd = await command_bus.get_command("payments", cmd_id)
+        assert cmd is not None
+        assert cmd.batch_id == batch_id
+
+    async def test_regular_command_no_batch_id(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test that regular commands have no batch_id."""
+        cmd_id = uuid4()
+
+        await command_bus.send(
+            domain="payments",
+            command_type="DebitAccount",
+            command_id=cmd_id,
+            data={},
+        )
+
+        cmd = await command_bus.get_command("payments", cmd_id)
+        assert cmd is not None
+        assert cmd.batch_id is None
+
+    async def test_command_max_attempts_inherited(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test that commands inherit max_attempts from BatchCommand or default."""
+        batch_id = uuid4()
+        cmd1_id = uuid4()
+        cmd2_id = uuid4()
+
+        await command_bus.create_batch(
+            domain="payments",
+            commands=[
+                BatchCommand(
+                    command_type="Cmd",
+                    command_id=cmd1_id,
+                    data={},
+                    # uses default
+                ),
+                BatchCommand(
+                    command_type="Cmd",
+                    command_id=cmd2_id,
+                    data={},
+                    max_attempts=5,  # override
+                ),
+            ],
+            batch_id=batch_id,
+        )
+
+        cmd1 = await command_bus.get_command("payments", cmd1_id)
+        assert cmd1 is not None
+        assert cmd1.max_attempts == 3  # default
+
+        cmd2 = await command_bus.get_command("payments", cmd2_id)
+        assert cmd2 is not None
+        assert cmd2.max_attempts == 5  # overridden

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -1,0 +1,480 @@
+"""Unit tests for batch creation functionality."""
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from commandbus.bus import CommandBus
+from commandbus.exceptions import DuplicateCommandError
+from commandbus.models import (
+    BatchCommand,
+    BatchMetadata,
+    BatchStatus,
+    CreateBatchResult,
+    SendResult,
+)
+
+
+class TestBatchCommand:
+    """Tests for BatchCommand dataclass."""
+
+    def test_batch_command_creation(self) -> None:
+        """Test creating a BatchCommand."""
+        cmd_id = uuid4()
+        cmd = BatchCommand(
+            command_type="DebitAccount",
+            command_id=cmd_id,
+            data={"account_id": "123", "amount": 100},
+        )
+
+        assert cmd.command_type == "DebitAccount"
+        assert cmd.command_id == cmd_id
+        assert cmd.data == {"account_id": "123", "amount": 100}
+        assert cmd.correlation_id is None
+        assert cmd.reply_to is None
+        assert cmd.max_attempts is None
+
+    def test_batch_command_with_optional_fields(self) -> None:
+        """Test creating a BatchCommand with optional fields."""
+        cmd_id = uuid4()
+        corr_id = uuid4()
+        cmd = BatchCommand(
+            command_type="DebitAccount",
+            command_id=cmd_id,
+            data={"account_id": "123"},
+            correlation_id=corr_id,
+            reply_to="payments__replies",
+            max_attempts=5,
+        )
+
+        assert cmd.correlation_id == corr_id
+        assert cmd.reply_to == "payments__replies"
+        assert cmd.max_attempts == 5
+
+
+class TestBatchMetadata:
+    """Tests for BatchMetadata dataclass."""
+
+    def test_batch_metadata_creation(self) -> None:
+        """Test creating a BatchMetadata."""
+        batch_id = uuid4()
+        now = datetime.now(UTC)
+        metadata = BatchMetadata(
+            domain="payments",
+            batch_id=batch_id,
+            status=BatchStatus.PENDING,
+            name="Test Batch",
+            total_count=3,
+            created_at=now,
+        )
+
+        assert metadata.domain == "payments"
+        assert metadata.batch_id == batch_id
+        assert metadata.status == BatchStatus.PENDING
+        assert metadata.name == "Test Batch"
+        assert metadata.total_count == 3
+        assert metadata.completed_count == 0
+        assert metadata.failed_count == 0
+        assert metadata.canceled_count == 0
+        assert metadata.in_troubleshooting_count == 0
+        assert metadata.started_at is None
+        assert metadata.completed_at is None
+
+    def test_batch_metadata_with_custom_data(self) -> None:
+        """Test creating a BatchMetadata with custom data."""
+        batch_id = uuid4()
+        custom = {"source": "csv", "file_id": "abc123"}
+        metadata = BatchMetadata(
+            domain="payments",
+            batch_id=batch_id,
+            custom_data=custom,
+        )
+
+        assert metadata.custom_data == custom
+
+
+class TestBatchStatus:
+    """Tests for BatchStatus enum."""
+
+    def test_batch_status_values(self) -> None:
+        """Test BatchStatus enum values."""
+        assert BatchStatus.PENDING.value == "PENDING"
+        assert BatchStatus.IN_PROGRESS.value == "IN_PROGRESS"
+        assert BatchStatus.COMPLETED.value == "COMPLETED"
+        assert BatchStatus.COMPLETED_WITH_FAILURES.value == "COMPLETED_WITH_FAILURES"
+
+
+class TestCreateBatchResult:
+    """Tests for CreateBatchResult dataclass."""
+
+    def test_create_batch_result(self) -> None:
+        """Test creating a CreateBatchResult."""
+        batch_id = uuid4()
+        cmd_id = uuid4()
+        result = CreateBatchResult(
+            batch_id=batch_id,
+            command_results=[SendResult(command_id=cmd_id, msg_id=1)],
+            total_commands=1,
+        )
+
+        assert result.batch_id == batch_id
+        assert len(result.command_results) == 1
+        assert result.total_commands == 1
+
+
+class TestCommandBusCreateBatch:
+    """Tests for CommandBus.create_batch() method."""
+
+    @pytest.fixture
+    def mock_pool(self) -> MagicMock:
+        """Create a mock connection pool with proper async context managers."""
+        pool = MagicMock()
+        conn = MagicMock()
+
+        @asynccontextmanager
+        async def mock_connection():
+            yield conn
+
+        @asynccontextmanager
+        async def mock_transaction():
+            yield None
+
+        pool.connection = mock_connection
+        conn.transaction = mock_transaction
+
+        return pool
+
+    @pytest.fixture
+    def command_bus(self, mock_pool: MagicMock) -> CommandBus:
+        """Create a CommandBus with mocked dependencies."""
+        return CommandBus(mock_pool, default_max_attempts=3)
+
+    @pytest.mark.asyncio
+    async def test_create_batch_success(self, command_bus: CommandBus) -> None:
+        """Test creating a batch with multiple commands."""
+        batch_id = uuid4()
+        cmd1_id = uuid4()
+        cmd2_id = uuid4()
+
+        with (
+            patch.object(
+                command_bus._command_repo, "exists_batch", new_callable=AsyncMock
+            ) as mock_exists,
+            patch.object(
+                command_bus._batch_repo, "save", new_callable=AsyncMock
+            ) as mock_batch_save,
+            patch.object(command_bus._pgmq, "send_batch", new_callable=AsyncMock) as mock_pgmq_send,
+            patch.object(
+                command_bus._command_repo, "save_batch", new_callable=AsyncMock
+            ) as mock_cmd_save,
+            patch.object(
+                command_bus._audit_logger, "log_batch", new_callable=AsyncMock
+            ) as mock_audit,
+            patch.object(command_bus._pgmq, "notify", new_callable=AsyncMock) as mock_notify,
+        ):
+            mock_exists.return_value = set()
+            mock_pgmq_send.return_value = [1, 2]
+
+            result = await command_bus.create_batch(
+                domain="payments",
+                commands=[
+                    BatchCommand(
+                        command_type="DebitAccount",
+                        command_id=cmd1_id,
+                        data={"account_id": "123", "amount": 100},
+                    ),
+                    BatchCommand(
+                        command_type="DebitAccount",
+                        command_id=cmd2_id,
+                        data={"account_id": "456", "amount": 200},
+                    ),
+                ],
+                batch_id=batch_id,
+                name="Test Batch",
+            )
+
+            assert result.batch_id == batch_id
+            assert result.total_commands == 2
+            assert len(result.command_results) == 2
+            assert result.command_results[0].command_id == cmd1_id
+            assert result.command_results[0].msg_id == 1
+            assert result.command_results[1].command_id == cmd2_id
+            assert result.command_results[1].msg_id == 2
+
+            mock_exists.assert_called_once()
+            mock_batch_save.assert_called_once()
+            mock_pgmq_send.assert_called_once()
+            mock_cmd_save.assert_called_once()
+            mock_audit.assert_called_once()
+            mock_notify.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_batch_sets_total_count(self, command_bus: CommandBus) -> None:
+        """Test that total_count is set correctly in batch metadata."""
+        batch_id = uuid4()
+        saved_batch: BatchMetadata | None = None
+
+        async def capture_batch(metadata: BatchMetadata, conn: MagicMock) -> None:
+            nonlocal saved_batch
+            saved_batch = metadata
+
+        with (
+            patch.object(
+                command_bus._command_repo, "exists_batch", new_callable=AsyncMock
+            ) as mock_exists,
+            patch.object(command_bus._batch_repo, "save", side_effect=capture_batch),
+            patch.object(command_bus._pgmq, "send_batch", new_callable=AsyncMock) as mock_send,
+            patch.object(command_bus._command_repo, "save_batch", new_callable=AsyncMock),
+            patch.object(command_bus._audit_logger, "log_batch", new_callable=AsyncMock),
+            patch.object(command_bus._pgmq, "notify", new_callable=AsyncMock),
+        ):
+            mock_exists.return_value = set()
+            mock_send.return_value = [1, 2, 3]
+
+            await command_bus.create_batch(
+                domain="payments",
+                commands=[
+                    BatchCommand(command_type="Cmd", command_id=uuid4(), data={}) for _ in range(3)
+                ],
+                batch_id=batch_id,
+            )
+
+            assert saved_batch is not None
+            assert saved_batch.total_count == 3
+            assert saved_batch.status == BatchStatus.PENDING
+            assert saved_batch.completed_count == 0
+
+    @pytest.mark.asyncio
+    async def test_create_batch_links_commands(self, command_bus: CommandBus) -> None:
+        """Test that commands have batch_id set."""
+        batch_id = uuid4()
+        saved_commands: list = []
+
+        async def capture_commands(metadata_list: list, queue: str, conn: MagicMock) -> None:
+            saved_commands.extend(metadata_list)
+
+        with (
+            patch.object(
+                command_bus._command_repo, "exists_batch", new_callable=AsyncMock
+            ) as mock_exists,
+            patch.object(command_bus._batch_repo, "save", new_callable=AsyncMock),
+            patch.object(command_bus._pgmq, "send_batch", new_callable=AsyncMock) as mock_send,
+            patch.object(command_bus._command_repo, "save_batch", side_effect=capture_commands),
+            patch.object(command_bus._audit_logger, "log_batch", new_callable=AsyncMock),
+            patch.object(command_bus._pgmq, "notify", new_callable=AsyncMock),
+        ):
+            mock_exists.return_value = set()
+            mock_send.return_value = [1, 2]
+
+            await command_bus.create_batch(
+                domain="payments",
+                commands=[
+                    BatchCommand(command_type="Cmd", command_id=uuid4(), data={}) for _ in range(2)
+                ],
+                batch_id=batch_id,
+            )
+
+            assert len(saved_commands) == 2
+            for cmd in saved_commands:
+                assert cmd.batch_id == batch_id
+
+    @pytest.mark.asyncio
+    async def test_create_batch_rejects_empty(self, command_bus: CommandBus) -> None:
+        """Test that empty batch is rejected."""
+        with pytest.raises(ValueError, match="Batch must contain at least one command"):
+            await command_bus.create_batch(
+                domain="payments",
+                commands=[],
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_batch_duplicate_in_batch(self, command_bus: CommandBus) -> None:
+        """Test that duplicate command_ids in the same batch are rejected."""
+        cmd_id = uuid4()
+
+        with pytest.raises(DuplicateCommandError):
+            await command_bus.create_batch(
+                domain="payments",
+                commands=[
+                    BatchCommand(command_type="Cmd", command_id=cmd_id, data={}),
+                    BatchCommand(command_type="Cmd", command_id=cmd_id, data={}),
+                ],
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_batch_duplicate_in_database(self, command_bus: CommandBus) -> None:
+        """Test that duplicate command_ids in database are rejected."""
+        existing_id = uuid4()
+
+        with (
+            patch.object(
+                command_bus._command_repo, "exists_batch", new_callable=AsyncMock
+            ) as mock_exists,
+        ):
+            mock_exists.return_value = {existing_id}
+
+            with pytest.raises(DuplicateCommandError):
+                await command_bus.create_batch(
+                    domain="payments",
+                    commands=[
+                        BatchCommand(
+                            command_type="Cmd",
+                            command_id=existing_id,
+                            data={},
+                        ),
+                    ],
+                )
+
+    @pytest.mark.asyncio
+    async def test_create_batch_generates_batch_id(self, command_bus: CommandBus) -> None:
+        """Test that batch_id is generated if not provided."""
+        with (
+            patch.object(
+                command_bus._command_repo, "exists_batch", new_callable=AsyncMock
+            ) as mock_exists,
+            patch.object(command_bus._batch_repo, "save", new_callable=AsyncMock),
+            patch.object(command_bus._pgmq, "send_batch", new_callable=AsyncMock) as mock_send,
+            patch.object(command_bus._command_repo, "save_batch", new_callable=AsyncMock),
+            patch.object(command_bus._audit_logger, "log_batch", new_callable=AsyncMock),
+            patch.object(command_bus._pgmq, "notify", new_callable=AsyncMock),
+        ):
+            mock_exists.return_value = set()
+            mock_send.return_value = [1]
+
+            result = await command_bus.create_batch(
+                domain="payments",
+                commands=[BatchCommand(command_type="Cmd", command_id=uuid4(), data={})],
+            )
+
+            assert result.batch_id is not None
+
+    @pytest.mark.asyncio
+    async def test_create_batch_with_custom_data(self, command_bus: CommandBus) -> None:
+        """Test creating a batch with custom metadata."""
+        saved_batch: BatchMetadata | None = None
+        custom = {"source": "csv", "file_id": "abc123"}
+
+        async def capture_batch(metadata: BatchMetadata, conn: MagicMock) -> None:
+            nonlocal saved_batch
+            saved_batch = metadata
+
+        with (
+            patch.object(
+                command_bus._command_repo, "exists_batch", new_callable=AsyncMock
+            ) as mock_exists,
+            patch.object(command_bus._batch_repo, "save", side_effect=capture_batch),
+            patch.object(command_bus._pgmq, "send_batch", new_callable=AsyncMock) as mock_send,
+            patch.object(command_bus._command_repo, "save_batch", new_callable=AsyncMock),
+            patch.object(command_bus._audit_logger, "log_batch", new_callable=AsyncMock),
+            patch.object(command_bus._pgmq, "notify", new_callable=AsyncMock),
+        ):
+            mock_exists.return_value = set()
+            mock_send.return_value = [1]
+
+            await command_bus.create_batch(
+                domain="payments",
+                commands=[BatchCommand(command_type="Cmd", command_id=uuid4(), data={})],
+                name="Import job 12345",
+                custom_data=custom,
+            )
+
+            assert saved_batch is not None
+            assert saved_batch.name == "Import job 12345"
+            assert saved_batch.custom_data == custom
+
+    @pytest.mark.asyncio
+    async def test_create_batch_uses_default_max_attempts(self, command_bus: CommandBus) -> None:
+        """Test that commands inherit default max_attempts."""
+        saved_commands: list = []
+
+        async def capture_commands(metadata_list: list, queue: str, conn: MagicMock) -> None:
+            saved_commands.extend(metadata_list)
+
+        with (
+            patch.object(
+                command_bus._command_repo, "exists_batch", new_callable=AsyncMock
+            ) as mock_exists,
+            patch.object(command_bus._batch_repo, "save", new_callable=AsyncMock),
+            patch.object(command_bus._pgmq, "send_batch", new_callable=AsyncMock) as mock_send,
+            patch.object(command_bus._command_repo, "save_batch", side_effect=capture_commands),
+            patch.object(command_bus._audit_logger, "log_batch", new_callable=AsyncMock),
+            patch.object(command_bus._pgmq, "notify", new_callable=AsyncMock),
+        ):
+            mock_exists.return_value = set()
+            mock_send.return_value = [1]
+
+            await command_bus.create_batch(
+                domain="payments",
+                commands=[BatchCommand(command_type="Cmd", command_id=uuid4(), data={})],
+            )
+
+            assert len(saved_commands) == 1
+            assert saved_commands[0].max_attempts == 3  # default
+
+    @pytest.mark.asyncio
+    async def test_create_batch_respects_command_max_attempts(
+        self, command_bus: CommandBus
+    ) -> None:
+        """Test that command-level max_attempts overrides default."""
+        saved_commands: list = []
+
+        async def capture_commands(metadata_list: list, queue: str, conn: MagicMock) -> None:
+            saved_commands.extend(metadata_list)
+
+        with (
+            patch.object(
+                command_bus._command_repo, "exists_batch", new_callable=AsyncMock
+            ) as mock_exists,
+            patch.object(command_bus._batch_repo, "save", new_callable=AsyncMock),
+            patch.object(command_bus._pgmq, "send_batch", new_callable=AsyncMock) as mock_send,
+            patch.object(command_bus._command_repo, "save_batch", side_effect=capture_commands),
+            patch.object(command_bus._audit_logger, "log_batch", new_callable=AsyncMock),
+            patch.object(command_bus._pgmq, "notify", new_callable=AsyncMock),
+        ):
+            mock_exists.return_value = set()
+            mock_send.return_value = [1]
+
+            await command_bus.create_batch(
+                domain="payments",
+                commands=[
+                    BatchCommand(command_type="Cmd", command_id=uuid4(), data={}, max_attempts=5)
+                ],
+            )
+
+            assert len(saved_commands) == 1
+            assert saved_commands[0].max_attempts == 5
+
+    @pytest.mark.asyncio
+    async def test_create_batch_audit_includes_batch_id(self, command_bus: CommandBus) -> None:
+        """Test that audit events include batch_id."""
+        batch_id = uuid4()
+        logged_events: list = []
+
+        async def capture_audit(events: list, conn: MagicMock) -> None:
+            logged_events.extend(events)
+
+        with (
+            patch.object(
+                command_bus._command_repo, "exists_batch", new_callable=AsyncMock
+            ) as mock_exists,
+            patch.object(command_bus._batch_repo, "save", new_callable=AsyncMock),
+            patch.object(command_bus._pgmq, "send_batch", new_callable=AsyncMock) as mock_send,
+            patch.object(command_bus._command_repo, "save_batch", new_callable=AsyncMock),
+            patch.object(command_bus._audit_logger, "log_batch", side_effect=capture_audit),
+            patch.object(command_bus._pgmq, "notify", new_callable=AsyncMock),
+        ):
+            mock_exists.return_value = set()
+            mock_send.return_value = [1]
+
+            await command_bus.create_batch(
+                domain="payments",
+                commands=[BatchCommand(command_type="Cmd", command_id=uuid4(), data={})],
+                batch_id=batch_id,
+            )
+
+            assert len(logged_events) == 1
+            _domain, _cmd_id, _event_type, details = logged_events[0]
+            assert details["batch_id"] == str(batch_id)

--- a/tests/unit/test_repositories.py
+++ b/tests/unit/test_repositories.py
@@ -98,6 +98,7 @@ class TestPostgresCommandRepositoryGet:
                 None,  # last_error_msg
                 now,  # created_at
                 now,  # updated_at
+                None,  # batch_id
             )
         )
 
@@ -487,6 +488,7 @@ class TestPostgresCommandRepositoryQuery:
                     None,  # last_error_msg
                     now,  # created_at
                     now,  # updated_at
+                    None,  # batch_id
                 ),
             ]
         )


### PR DESCRIPTION
## Summary

Implements S041 - Create a Batch with Commands from F009 Batch Commands feature.

- Add atomic batch creation capability to CommandBus with `create_batch()` and `get_batch()` methods
- Create `command_bus_batch` table schema with status tracking counters (total, completed, failed, canceled, in_troubleshooting)
- Add `batch_id` column to `command_bus_command` table for FK relationship
- Create `BatchCommand`, `BatchMetadata`, `BatchStatus`, `CreateBatchResult` models
- Implement `PostgresBatchRepository` for batch CRUD operations
- Full rollback on duplicate command IDs within batch or against existing commands

## Test plan

- [x] 17 unit tests for batch models and CommandBus.create_batch()
- [x] 13 integration tests for atomic creation, rollback, and retrieval
- [x] All 349 tests pass with 88.65% coverage (exceeds 80% requirement)
- [x] Pre-commit hooks pass (ruff, mypy, coverage)

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)