### PR TITLE
feat(batch): add batch completion callbacks (S043)

### DIFF
--- a/docs/features/stories/S043-batch-completion-callback.md
+++ b/docs/features/stories/S043-batch-completion-callback.md
@@ -1,0 +1,189 @@
+# S043: Receive Callback on Batch Completion
+
+## Parent Feature
+
+[F009 - Batch Commands](../F009-batch-commands.md)
+
+## User Story
+
+**As a** application developer
+**I want** to receive an async callback when a batch completes
+**So that** I can trigger follow-up actions without polling
+
+## Context
+
+When all commands in a batch reach terminal states (COMPLETED, FAILED, or CANCELED - after TSQ resolution), the application may need to perform follow-up actions like sending notifications, updating external systems, or starting dependent workflows. An async callback provides an event-driven alternative to polling.
+
+## Acceptance Criteria (Given-When-Then)
+
+### Scenario: Callback invoked on successful batch completion
+
+**Given** a batch created with on_complete callback registered
+**And** all 3 commands in the batch complete successfully
+**When** the last command completes
+**Then** the on_complete callback is invoked with BatchMetadata
+**And** the BatchMetadata includes:
+  - batch_id matching the batch
+  - status: "COMPLETED"
+  - completed_count: 3
+  - completed_at: set to completion timestamp
+
+### Scenario: Callback invoked on batch completion with failures
+
+**Given** a batch created with on_complete callback registered
+**And** the batch has 2 completed commands and 1 canceled (after TSQ)
+**When** the operator cancels the TSQ command
+**Then** the on_complete callback is invoked with BatchMetadata
+**And** the BatchMetadata includes:
+  - status: "COMPLETED_WITH_FAILURES"
+  - completed_count: 2
+  - canceled_count: 1
+
+### Scenario: Callback not invoked while commands in TSQ
+
+**Given** a batch with on_complete callback registered
+**And** the batch has 2 completed commands and 1 in TSQ
+**Then** the callback is NOT invoked
+**And** the batch remains in "IN_PROGRESS" status
+
+### Scenario: Callback error does not affect batch completion
+
+**Given** a batch with on_complete callback that raises an exception
+**When** the batch completes
+**Then** the callback exception is logged
+**And** the batch status is still "COMPLETED"
+**And** the BATCH_COMPLETED audit event is still recorded
+**And** no exception is propagated to the worker
+
+### Scenario: No callback registered
+
+**Given** a batch created without on_complete callback
+**When** the batch completes
+**Then** the batch status changes to "COMPLETED"
+**And** the BATCH_COMPLETED audit event is recorded
+**And** no callback invocation is attempted
+
+### Scenario: Callback receives accurate final state
+
+**Given** a batch with multiple concurrent command completions
+**When** the last command completes and triggers the callback
+**Then** the callback receives the final accurate BatchMetadata
+**And** all counts reflect the true final state
+
+### Scenario: Callback registry survives worker restart (best effort)
+
+**Given** a batch with callback registered
+**When** the worker process restarts before batch completion
+**Then** the callback is lost (not persisted)
+**And** the batch still completes normally
+**And** applications should poll for completion as fallback
+
+## Test Mapping
+
+| Criterion | Test Type | Test Location |
+|-----------|-----------|---------------|
+| Callback invoked on success | Integration | `tests/integration/test_batch.py::test_batch_callback_on_complete` |
+| Callback receives metadata | Integration | `tests/integration/test_batch.py::test_batch_callback_metadata` |
+| Callback on COMPLETED_WITH_FAILURES | Integration | `tests/integration/test_batch.py::test_batch_callback_with_failures` |
+| Callback not called with TSQ pending | Integration | `tests/integration/test_batch.py::test_batch_callback_not_called_with_tsq` |
+| Callback error handled | Integration | `tests/integration/test_batch.py::test_batch_callback_error_handled` |
+| No callback OK | Unit | `tests/unit/test_batch.py::test_batch_no_callback` |
+
+## Story Size
+
+M (2000-4000 tokens, medium feature)
+
+## Priority (MoSCoW)
+
+Should Have
+
+## Dependencies
+
+- S041 (Create batch) completed
+- S042 (Batch status tracking) completed
+
+## Technical Notes
+
+### Callback Registry
+
+```python
+# Global in-memory registry
+_batch_callbacks: dict[tuple[str, UUID], BatchCompletionCallback] = {}
+
+def register_batch_callback(
+    domain: str,
+    batch_id: UUID,
+    callback: BatchCompletionCallback,
+) -> None:
+    _batch_callbacks[(domain, batch_id)] = callback
+
+def get_batch_callback(
+    domain: str,
+    batch_id: UUID,
+) -> BatchCompletionCallback | None:
+    return _batch_callbacks.get((domain, batch_id))
+
+def remove_batch_callback(domain: str, batch_id: UUID) -> None:
+    _batch_callbacks.pop((domain, batch_id), None)
+```
+
+### Callback Invocation
+
+Callback should be invoked by the worker/TSQ operation that triggers batch completion:
+
+```python
+async def _check_and_invoke_batch_callback(
+    domain: str,
+    batch_id: UUID,
+    batch_repo: BatchRepository,
+) -> None:
+    callback = get_batch_callback(domain, batch_id)
+    if callback is None:
+        return
+
+    batch = await batch_repo.get(domain, batch_id)
+    if batch is None or batch.status not in ("COMPLETED", "COMPLETED_WITH_FAILURES"):
+        return
+
+    try:
+        await callback(batch)
+    except Exception as e:
+        logger.exception(f"Batch callback error for {batch_id}: {e}")
+    finally:
+        remove_batch_callback(domain, batch_id)
+```
+
+### Thread Safety
+
+- Use threading.Lock or asyncio.Lock for registry access if needed
+- Callback invocation should be outside any database transactions
+
+## LLM Agent Instructions
+
+**Reference Files:**
+- `src/commandbus/batch.py` - New module for callback registry
+- `src/commandbus/worker.py` - Check for batch completion after command complete
+- `src/commandbus/ops/troubleshooting.py` - Check for batch completion after TSQ ops
+- `src/commandbus/repositories/batch.py` - Get batch for callback
+
+**Constraints:**
+- Callbacks are async functions
+- Callback exceptions must not propagate to caller
+- Callbacks are in-memory only (not persisted)
+- Callback invoked exactly once per batch completion
+- Callback receives final, accurate batch state
+
+**Verification Steps:**
+1. Run `pytest tests/integration/test_batch.py::test_batch_callback* -v`
+2. Verify callback receives accurate metadata
+3. Verify callback errors are handled gracefully
+
+## Definition of Done
+
+- [ ] Code complete and reviewed
+- [ ] Callback registry implemented
+- [ ] Unit tests written and passing
+- [ ] Integration tests written and passing
+- [ ] Error handling verified
+- [ ] Acceptance criteria verified
+- [ ] No regressions in related functionality

--- a/src/commandbus/__init__.py
+++ b/src/commandbus/__init__.py
@@ -1,5 +1,13 @@
 """Command Bus - A Python library for Command Bus over PostgreSQL + PGMQ."""
 
+from commandbus.batch import (
+    BatchCompletionCallback,
+    check_and_invoke_batch_callback,
+    clear_all_callbacks,
+    get_batch_callback,
+    register_batch_callback,
+    remove_batch_callback,
+)
 from commandbus.bus import CommandBus
 from commandbus.exceptions import (
     BatchNotFoundError,
@@ -42,6 +50,7 @@ __all__ = [
     "AuditEvent",
     "AuditEventType",
     "BatchCommand",
+    "BatchCompletionCallback",
     "BatchMetadata",
     "BatchNotFoundError",
     "BatchSendResult",
@@ -75,7 +84,12 @@ __all__ = [
     "TroubleshootingItem",
     "TroubleshootingQueue",
     "Worker",
+    "check_and_invoke_batch_callback",
+    "clear_all_callbacks",
+    "get_batch_callback",
     "handler",
+    "register_batch_callback",
+    "remove_batch_callback",
 ]
 
 __version__ = "0.1.0"

--- a/src/commandbus/batch.py
+++ b/src/commandbus/batch.py
@@ -1,0 +1,139 @@
+"""Batch completion callback registry and utilities.
+
+This module provides an in-memory registry for batch completion callbacks.
+Callbacks are registered when a batch is created with an on_complete parameter
+and are invoked when the batch reaches a terminal state (COMPLETED or
+COMPLETED_WITH_FAILURES).
+
+Note: Callbacks are in-memory only and will be lost on worker restart.
+Applications should poll for completion as a fallback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from commandbus.models import BatchMetadata
+    from commandbus.repositories.batch import PostgresBatchRepository
+
+logger = logging.getLogger(__name__)
+
+# Type alias for batch completion callbacks
+BatchCompletionCallback = Callable[["BatchMetadata"], Awaitable[Any]]
+
+# Global in-memory registry for batch callbacks
+# Key: (domain, batch_id) tuple, Value: callback function
+_batch_callbacks: dict[tuple[str, UUID], BatchCompletionCallback] = {}
+
+# Lock for thread-safe access to the registry
+_registry_lock = asyncio.Lock()
+
+
+async def register_batch_callback(
+    domain: str,
+    batch_id: UUID,
+    callback: BatchCompletionCallback,
+) -> None:
+    """Register a callback for batch completion.
+
+    Args:
+        domain: The domain of the batch
+        batch_id: The batch ID
+        callback: Async function to call when batch completes.
+                  Receives BatchMetadata as argument.
+    """
+    async with _registry_lock:
+        _batch_callbacks[(domain, batch_id)] = callback
+    logger.debug(f"Registered callback for batch {domain}.{batch_id}")
+
+
+def get_batch_callback(
+    domain: str,
+    batch_id: UUID,
+) -> BatchCompletionCallback | None:
+    """Get the registered callback for a batch.
+
+    Note: This does not use the lock for read performance.
+    Dictionary reads are atomic in Python.
+
+    Args:
+        domain: The domain of the batch
+        batch_id: The batch ID
+
+    Returns:
+        The callback if registered, None otherwise
+    """
+    return _batch_callbacks.get((domain, batch_id))
+
+
+async def remove_batch_callback(domain: str, batch_id: UUID) -> None:
+    """Remove a batch callback from the registry.
+
+    Args:
+        domain: The domain of the batch
+        batch_id: The batch ID
+    """
+    async with _registry_lock:
+        _batch_callbacks.pop((domain, batch_id), None)
+    logger.debug(f"Removed callback for batch {domain}.{batch_id}")
+
+
+async def check_and_invoke_batch_callback(
+    domain: str,
+    batch_id: UUID,
+    batch_repo: PostgresBatchRepository,
+) -> None:
+    """Check if batch is complete and invoke callback if registered.
+
+    This function should be called after any operation that might complete a batch
+    (e.g., command complete, TSQ cancel, TSQ complete).
+
+    The callback is invoked outside of any database transaction.
+    Callback exceptions are caught and logged but not propagated.
+
+    Args:
+        domain: The domain of the batch
+        batch_id: The batch ID
+        batch_repo: Batch repository to fetch batch metadata
+    """
+    callback = get_batch_callback(domain, batch_id)
+    if callback is None:
+        return
+
+    # Fetch the batch to check its status
+    batch = await batch_repo.get(domain, batch_id)
+    if batch is None:
+        logger.warning(f"Batch {domain}.{batch_id} not found for callback")
+        await remove_batch_callback(domain, batch_id)
+        return
+
+    # Only invoke callback if batch is in a terminal state
+    if batch.status.value not in ("COMPLETED", "COMPLETED_WITH_FAILURES"):
+        return
+
+    try:
+        logger.info(
+            f"Invoking callback for batch {domain}.{batch_id} (status={batch.status.value})"
+        )
+        await callback(batch)
+        logger.debug(f"Callback for batch {domain}.{batch_id} completed successfully")
+    except Exception as e:
+        logger.exception(f"Batch callback error for {domain}.{batch_id}: {e}")
+    finally:
+        # Always remove the callback after invocation (success or failure)
+        await remove_batch_callback(domain, batch_id)
+
+
+def clear_all_callbacks() -> None:
+    """Clear all registered callbacks.
+
+    This is primarily useful for testing.
+    """
+    _batch_callbacks.clear()
+    logger.debug("Cleared all batch callbacks")


### PR DESCRIPTION
## Summary
- Add async callback support for batch completion events
- Applications can provide an `on_complete` callback to `create_batch()` that is invoked when the batch reaches a terminal state
- Callbacks are invoked after command completion in Worker and after TSQ operations (cancel/complete)
- Callbacks are isolated - exceptions are logged but don't affect batch processing

## Key Changes
- New `src/commandbus/batch.py` with callback registry (thread-safe using asyncio.Lock)
- `CommandBus.create_batch()` now accepts optional `on_complete` callback parameter
- `Worker.complete()` invokes callbacks when batch completes
- `TroubleshootingQueue.operator_cancel()` and `operator_complete()` invoke callbacks

## Test plan
- [x] Unit tests for callback registry (register, get, remove, clear)
- [x] Unit tests for check_and_invoke_batch_callback with all states
- [x] Unit tests for create_batch with on_complete callback
- [x] Integration tests for callback invocation on batch completion
- [x] Integration tests for callback invocation on TSQ operations
- [x] Integration test for callback exception isolation
- [x] Coverage >= 80% (currently 81.85%)

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)