### PR TITLE
feat(S044): Add batch query methods and send() batch validation

### DIFF
--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -8,6 +8,7 @@ from psycopg_pool import AsyncConnectionPool
 
 from commandbus import (
     BatchCommand,
+    BatchNotFoundError,
     BatchStatus,
     CommandBus,
     CommandStatus,
@@ -1022,3 +1023,326 @@ class TestBatchCompletionCallback:
         assert batch.status == BatchStatus.COMPLETED
 
         clear_all_callbacks()
+
+
+@pytest.mark.asyncio
+class TestBatchQueries:
+    """Integration tests for S044: Query Batches and Their Commands."""
+
+    async def test_list_batches(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test list_batches returns all batches for a domain."""
+        batch_ids = []
+        for i in range(5):
+            result = await command_bus.create_batch(
+                domain="payments",
+                commands=[
+                    BatchCommand(
+                        command_type="DebitAccount",
+                        command_id=uuid4(),
+                        data={"index": i},
+                    ),
+                ],
+                name=f"Batch {i}",
+            )
+            batch_ids.append(result.batch_id)
+
+        # List all batches
+        batches = await command_bus.list_batches("payments")
+        assert len(batches) == 5
+
+        # Verify ordering (newest first - by created_at DESC)
+        returned_ids = [b.batch_id for b in batches]
+        assert returned_ids == list(reversed(batch_ids))
+
+    async def test_list_batches_status_filter(
+        self,
+        command_bus: CommandBus,
+        pool: AsyncConnectionPool,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test list_batches with status filter."""
+        # Create multiple batches
+        await command_bus.create_batch(
+            domain="payments",
+            commands=[
+                BatchCommand(
+                    command_type="DebitAccount",
+                    command_id=uuid4(),
+                    data={},
+                ),
+            ],
+        )
+
+        await command_bus.create_batch(
+            domain="payments",
+            commands=[
+                BatchCommand(
+                    command_type="DebitAccount",
+                    command_id=uuid4(),
+                    data={},
+                ),
+            ],
+        )
+
+        # Start processing one batch to make it IN_PROGRESS
+        worker = Worker(pool, domain="payments")
+        received = await worker.receive(batch_size=1)
+        assert len(received) == 1
+        # Don't complete - leave in progress
+
+        # Filter by status
+        pending = await command_bus.list_batches("payments", status=BatchStatus.PENDING)
+        in_progress = await command_bus.list_batches("payments", status=BatchStatus.IN_PROGRESS)
+
+        # One batch should be pending, one in progress
+        assert len(pending) == 1
+        assert len(in_progress) == 1
+        assert in_progress[0].status == BatchStatus.IN_PROGRESS
+
+    async def test_list_batches_pagination(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test list_batches with pagination."""
+        # Create 25 batches
+        for i in range(25):
+            await command_bus.create_batch(
+                domain="payments",
+                commands=[
+                    BatchCommand(
+                        command_type="Cmd",
+                        command_id=uuid4(),
+                        data={"index": i},
+                    ),
+                ],
+            )
+
+        # Get first page
+        page1 = await command_bus.list_batches("payments", limit=10, offset=0)
+        assert len(page1) == 10
+
+        # Get second page
+        page2 = await command_bus.list_batches("payments", limit=10, offset=10)
+        assert len(page2) == 10
+
+        # Get third page
+        page3 = await command_bus.list_batches("payments", limit=10, offset=20)
+        assert len(page3) == 5
+
+        # Verify no overlap
+        all_ids = set()
+        for batch in page1 + page2 + page3:
+            assert batch.batch_id not in all_ids
+            all_ids.add(batch.batch_id)
+        assert len(all_ids) == 25
+
+    async def test_list_batch_commands(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test list_batch_commands returns all commands in a batch."""
+        batch_id = uuid4()
+        cmd_ids = [uuid4() for _ in range(5)]
+
+        await command_bus.create_batch(
+            domain="payments",
+            commands=[
+                BatchCommand(
+                    command_type="DebitAccount",
+                    command_id=cmd_id,
+                    data={"index": i},
+                )
+                for i, cmd_id in enumerate(cmd_ids)
+            ],
+            batch_id=batch_id,
+        )
+
+        # List commands in batch
+        commands = await command_bus.list_batch_commands("payments", batch_id)
+        assert len(commands) == 5
+
+        # Verify all commands belong to batch
+        for cmd in commands:
+            assert cmd.batch_id == batch_id
+            assert cmd.command_id in cmd_ids
+
+    async def test_list_batch_commands_with_status_filter(
+        self,
+        command_bus: CommandBus,
+        pool: AsyncConnectionPool,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test list_batch_commands with status filter."""
+        batch_id = uuid4()
+        cmd_ids = [uuid4() for _ in range(3)]
+
+        await command_bus.create_batch(
+            domain="payments",
+            commands=[
+                BatchCommand(
+                    command_type="DebitAccount",
+                    command_id=cmd_id,
+                    data={},
+                )
+                for cmd_id in cmd_ids
+            ],
+            batch_id=batch_id,
+        )
+
+        # Create worker and complete one command
+        registry = HandlerRegistry()
+
+        @registry.handler("payments", "DebitAccount")
+        async def handle_debit(command, context):
+            return {"processed": True}
+
+        worker = Worker(pool, domain="payments", registry=registry)
+        received = await worker.receive(batch_size=1)
+        await worker.complete(received[0], result={"processed": True})
+
+        # List pending commands
+        pending = await command_bus.list_batch_commands(
+            "payments", batch_id, status=CommandStatus.PENDING
+        )
+        assert len(pending) == 2
+
+        # List completed commands
+        completed = await command_bus.list_batch_commands(
+            "payments", batch_id, status=CommandStatus.COMPLETED
+        )
+        assert len(completed) == 1
+
+    async def test_list_batch_commands_empty_for_nonexistent(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test list_batch_commands returns empty list for non-existent batch."""
+        commands = await command_bus.list_batch_commands("payments", uuid4())
+        assert commands == []
+
+    async def test_list_batches_domain_scoped(
+        self,
+        command_bus: CommandBus,
+        pool: AsyncConnectionPool,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test that list_batches is domain-scoped."""
+        # Create queue for orders domain
+        async with pool.connection() as conn:
+            await conn.execute("SELECT pgmq.create('orders__commands')")
+            await conn.execute("SELECT pgmq.create('orders__replies')")
+
+        # Create batches in payments domain
+        for _ in range(3):
+            await command_bus.create_batch(
+                domain="payments",
+                commands=[
+                    BatchCommand(
+                        command_type="Cmd",
+                        command_id=uuid4(),
+                        data={},
+                    ),
+                ],
+            )
+
+        # List batches in orders domain (should be empty)
+        orders_batches = await command_bus.list_batches("orders")
+        assert len(orders_batches) == 0
+
+        # List batches in payments domain (should have 3)
+        payments_batches = await command_bus.list_batches("payments")
+        assert len(payments_batches) == 3
+
+
+@pytest.mark.asyncio
+class TestSendWithBatchValidation:
+    """Integration tests for S044: Send with batch_id validation."""
+
+    async def test_send_with_nonexistent_batch_raises_error(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test send with non-existent batch_id raises BatchNotFoundError."""
+        fake_batch_id = uuid4()
+        cmd_id = uuid4()
+
+        with pytest.raises(BatchNotFoundError) as exc_info:
+            await command_bus.send(
+                domain="payments",
+                command_type="DebitAccount",
+                command_id=cmd_id,
+                data={"amount": 100},
+                batch_id=fake_batch_id,
+            )
+
+        assert str(fake_batch_id) in str(exc_info.value)
+        assert "payments" in str(exc_info.value)
+
+        # Command should not exist
+        cmd = await command_bus.get_command("payments", cmd_id)
+        assert cmd is None
+
+    async def test_send_with_valid_batch_succeeds(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test send with valid batch_id succeeds."""
+        # Create a batch first
+        batch_result = await command_bus.create_batch(
+            domain="payments",
+            commands=[
+                BatchCommand(
+                    command_type="DebitAccount",
+                    command_id=uuid4(),
+                    data={},
+                ),
+            ],
+        )
+
+        # Send additional command to the batch
+        cmd_id = uuid4()
+        result = await command_bus.send(
+            domain="payments",
+            command_type="CreditAccount",
+            command_id=cmd_id,
+            data={"amount": 50},
+            batch_id=batch_result.batch_id,
+        )
+
+        assert result.command_id == cmd_id
+
+        # Verify command has batch_id
+        cmd = await command_bus.get_command("payments", cmd_id)
+        assert cmd is not None
+        assert cmd.batch_id == batch_result.batch_id
+
+    async def test_send_without_batch_id_works(
+        self,
+        command_bus: CommandBus,
+        cleanup_payments_domain: None,
+    ) -> None:
+        """Test send without batch_id still works."""
+        cmd_id = uuid4()
+
+        result = await command_bus.send(
+            domain="payments",
+            command_type="DebitAccount",
+            command_id=cmd_id,
+            data={"amount": 100},
+        )
+
+        assert result.command_id == cmd_id
+
+        # Verify command has no batch_id
+        cmd = await command_bus.get_command("payments", cmd_id)
+        assert cmd is not None
+        assert cmd.batch_id is None


### PR DESCRIPTION
## Summary

- Add `list_batches()` method to CommandBus for listing batches by domain with optional status filter and pagination
- Add `list_batch_commands()` method to CommandBus for listing commands in a specific batch with optional status filter and pagination  
- Add `list_by_batch()` method to PostgresCommandRepository
- Add optional `batch_id` parameter to `send()` with `BatchNotFoundError` validation

## Test plan

- [x] Unit tests for all new query methods
- [x] Integration tests for batch queries with real database
- [x] Integration tests for send() with batch_id validation
- [x] All 412 tests pass with 91.69% coverage

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)