### PR TITLE
Simplify batch counter updates with consolidated stored procedures

### DIFF
--- a/src/commandbus/bus.py
+++ b/src/commandbus/bus.py
@@ -592,7 +592,6 @@ class CommandBus:
                 status=BatchStatus.PENDING,
                 total_count=len(commands),
                 completed_count=0,
-                failed_count=0,
                 canceled_count=0,
                 in_troubleshooting_count=0,
                 created_at=now,

--- a/src/commandbus/models.py
+++ b/src/commandbus/models.py
@@ -301,7 +301,6 @@ class BatchMetadata:
         status: Current batch status
         total_count: Total number of commands in the batch
         completed_count: Number of successfully completed commands
-        failed_count: Number of failed commands (deprecated, use canceled_count)
         canceled_count: Number of canceled commands (after TSQ resolution)
         in_troubleshooting_count: Number of commands currently in TSQ
         created_at: Batch creation timestamp
@@ -316,7 +315,6 @@ class BatchMetadata:
     custom_data: dict[str, Any] | None = None
     total_count: int = 0
     completed_count: int = 0
-    failed_count: int = 0
     canceled_count: int = 0
     in_troubleshooting_count: int = 0
     created_at: datetime = field(default_factory=datetime.utcnow)

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -73,7 +73,6 @@ class TestCreateBatchAtomic:
         assert batch.status == BatchStatus.PENDING
         assert batch.total_count == 3
         assert batch.completed_count == 0
-        assert batch.failed_count == 0
         assert batch.canceled_count == 0
         assert batch.in_troubleshooting_count == 0
 


### PR DESCRIPTION
## Summary

- Remove `failed_count` from schema and models (failed commands go to TSQ, not a terminal state)
- Create `sp_update_batch_counters` helper SP for centralized batch counter logic
- Modify `sp_receive_command` to handle batch start tracking (PENDING → IN_PROGRESS)
- Modify `sp_finish_command` to accept `batch_id` and return `is_batch_complete` flag
- Add `sp_tsq_complete`, `sp_tsq_cancel`, `sp_tsq_retry` stored procedures
- Simplify Python code by removing explicit `batch_repo.update_on_*` calls
- Use `is_batch_complete` return value for callback triggering (S043)

## Changes

### Database Schema
- Removed `failed_count` column from `command_bus_batch` table
- Batch completion formula: `completed_count + canceled_count = total_count AND in_troubleshooting_count = 0`

### Stored Procedures
- `sp_update_batch_counters(domain, batch_id, update_type)` - centralized counter logic
- Updated `sp_receive_command` to call `sp_start_batch` for batch tracking
- Updated `sp_finish_command` to accept `batch_id` and return `is_batch_complete`
- Added TSQ operations: `sp_tsq_complete`, `sp_tsq_cancel`, `sp_tsq_retry`

### Python Code
- Removed `failed_count` from `BatchMetadata` model
- Replaced `batch_repo.update_on_*` methods with simpler `tsq_complete`, `tsq_cancel`, `tsq_retry`
- Worker no longer makes explicit batch_repo calls (handled in SPs)
- Added `invoke_batch_callback` function, deprecated `check_and_invoke_batch_callback`

## Test plan

- [x] Unit tests pass (284 tests)
- [x] Linting passes (ruff, mypy)
- [x] Coverage check passes (≥80%)
- [ ] Integration tests pass

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)