### PR TITLE
S046: Create V001 commandbus schema migration

### DIFF
--- a/docs/features/F010-database-schema-management.md
+++ b/docs/features/F010-database-schema-management.md
@@ -1,0 +1,122 @@
+# F010: Database Schema Management
+
+## Problem Statement
+
+The current database schema management has several issues:
+
+1. **Dual sources of truth**: `scripts/init-db.sql` and `tests/e2e/migrations/` contain different schema definitions
+2. **Out of sync**: E2E migrations are missing:
+   - `command_bus_batch` table
+   - `batch_id` column on `command_bus_command`
+   - All stored procedures (`sp_receive_command`, `sp_finish_command`, `sp_update_batch_counters`, etc.)
+3. **No schema separation**: Command bus tables and e2e test tables are mixed in the public schema
+4. **No migration strategy**: Development uses `init-db.sql` which recreates everything, but production needs versioned migrations
+
+## Goals
+
+1. Establish migrations as the single source of truth for all database changes
+2. Separate concerns using PostgreSQL schemas:
+   - `commandbus` schema: Core command bus tables and stored procedures
+   - `e2e` schema: Test-specific tables (`test_command`, `e2e_config`)
+3. Consolidate all current command bus objects into V1 migration
+4. Move e2e-specific objects to V2 migration
+5. Docker development should use the same migration system
+
+## Schema Design
+
+### `commandbus` Schema (V1)
+
+Tables:
+- `commandbus.command` (renamed from `command_bus_command`)
+- `commandbus.batch` (renamed from `command_bus_batch`)
+- `commandbus.audit` (renamed from `command_bus_audit`)
+- `commandbus.payload_archive` (renamed from `command_bus_payload_archive`)
+
+Stored Procedures:
+- `commandbus.sp_receive_command`
+- `commandbus.sp_finish_command`
+- `commandbus.sp_start_batch`
+- `commandbus.sp_update_batch_counters`
+- `commandbus.sp_tsq_complete`
+- `commandbus.sp_tsq_cancel`
+- `commandbus.sp_tsq_retry`
+
+### `e2e` Schema (V2)
+
+Tables:
+- `e2e.test_command`
+- `e2e.config`
+
+## Migration Strategy
+
+### Directory Structure
+```
+migrations/
+├── V001__commandbus_schema.sql    # Core command bus (tables + SPs)
+├── V002__e2e_schema.sql           # E2E test tables (optional)
+└── ...
+```
+
+### Docker Development
+- Replace `scripts/init-db.sql` with Flyway migrations
+- `docker-compose.yml` runs Flyway on startup
+- Same migrations used for dev, integration tests, and e2e tests
+
+### Python Code Changes
+- Update all SQL queries to use schema-qualified names (e.g., `commandbus.command`)
+- Or set `search_path` on connection to include `commandbus` schema
+
+## Stories
+
+### S046: Consolidate Command Bus Schema (V1)
+Create `V001__commandbus_schema.sql` containing:
+- Create `commandbus` schema
+- All command bus tables with proper naming
+- All stored procedures
+- All indexes
+
+### S047: Create E2E Schema (V2)
+Create `V002__e2e_schema.sql` containing:
+- Create `e2e` schema
+- `test_command` table
+- `config` table with defaults
+
+### S048: Update Docker Compose
+- Add Flyway container or init script
+- Remove `scripts/init-db.sql`
+- Ensure migrations run on container startup
+
+### S049: Update Python Code
+- Update repository classes to use schema-qualified table names
+- Update stored procedure calls
+- Ensure backward compatibility during transition
+
+### S050: Update Integration Tests
+- Tests should use the same migration system
+- Clean up between test runs without recreating schema
+
+## Decision Points
+
+1. **Table naming**: Keep `command_bus_` prefix or use schema + simple names?
+   - Option A: `commandbus.command_bus_command` (redundant)
+   - Option B: `commandbus.command` (cleaner, breaking change)
+
+2. **PGMQ queues**: PGMQ creates tables in `pgmq` schema - no changes needed
+
+3. **Search path vs qualified names**:
+   - Option A: Set `search_path = commandbus, pgmq, public` on connections
+   - Option B: Use fully qualified names everywhere
+
+4. **Backward compatibility**: How to handle existing deployments?
+   - This is a development project, so full migration is acceptable
+
+## Acceptance Criteria
+
+- [ ] Single source of truth for database schema (migrations only)
+- [ ] `commandbus` schema contains all command bus objects
+- [ ] `e2e` schema contains test-specific objects
+- [ ] Docker development uses Flyway migrations
+- [ ] Integration tests use same migration system
+- [ ] E2E tests use same migration system
+- [ ] `scripts/init-db.sql` removed or deprecated
+- [ ] All Python code works with new schema structure

--- a/docs/features/stories/S046-commandbus-schema-migration.md
+++ b/docs/features/stories/S046-commandbus-schema-migration.md
@@ -1,0 +1,148 @@
+# S046: Consolidate Command Bus Schema (V1 Migration)
+
+## Parent Feature
+
+[F010 - Database Schema Management](../F010-database-schema-management.md)
+
+## User Story
+
+**As a** platform engineer
+**I want** all command bus database objects consolidated into a dedicated `commandbus` schema
+**So that** the database is properly organized and migrations are the single source of truth
+
+## Context
+
+Currently, command bus tables exist in the public schema and are defined in two places: `scripts/init-db.sql` (complete) and `tests/e2e/migrations/` (outdated). This story consolidates everything into a single V1 migration file that creates the `commandbus` schema with all current tables and stored procedures.
+
+## Acceptance Criteria (Given-When-Then)
+
+### Scenario: Create commandbus schema with all tables
+
+**Given** a fresh PostgreSQL database with PGMQ extension
+**When** the V001 migration runs
+**Then** the `commandbus` schema is created
+**And** the following tables exist in `commandbus` schema:
+  - `commandbus.command` (command metadata)
+  - `commandbus.batch` (batch tracking)
+  - `commandbus.audit` (audit events)
+  - `commandbus.payload_archive` (archived payloads)
+**And** all required indexes are created
+**And** foreign key from `command.batch_id` to `batch` exists
+
+### Scenario: Create all stored procedures
+
+**Given** the commandbus schema exists
+**When** the V001 migration completes
+**Then** the following stored procedures exist:
+  - `commandbus.sp_receive_command`
+  - `commandbus.sp_finish_command`
+  - `commandbus.sp_start_batch`
+  - `commandbus.sp_update_batch_counters`
+  - `commandbus.sp_tsq_complete`
+  - `commandbus.sp_tsq_cancel`
+  - `commandbus.sp_tsq_retry`
+
+### Scenario: Migration is idempotent
+
+**Given** the V001 migration has already run
+**When** Flyway is run again
+**Then** the migration is skipped (already applied)
+**And** no errors occur
+
+### Scenario: Tables have correct structure
+
+**Given** the V001 migration has run
+**When** I describe the `commandbus.command` table
+**Then** it has columns:
+  - domain (TEXT NOT NULL)
+  - queue_name (TEXT NOT NULL)
+  - msg_id (BIGINT NULL)
+  - command_id (UUID NOT NULL)
+  - command_type (TEXT NOT NULL)
+  - status (TEXT NOT NULL)
+  - attempts (INT NOT NULL DEFAULT 0)
+  - max_attempts (INT NOT NULL)
+  - lease_expires_at (TIMESTAMPTZ NULL)
+  - last_error_type (TEXT NULL)
+  - last_error_code (TEXT NULL)
+  - last_error_msg (TEXT NULL)
+  - created_at (TIMESTAMPTZ NOT NULL DEFAULT NOW())
+  - updated_at (TIMESTAMPTZ NOT NULL DEFAULT NOW())
+  - reply_queue (TEXT NOT NULL DEFAULT '')
+  - correlation_id (UUID NULL)
+  - batch_id (UUID NULL)
+
+### Scenario: Batch table has correct structure
+
+**Given** the V001 migration has run
+**When** I describe the `commandbus.batch` table
+**Then** it has columns:
+  - domain (TEXT NOT NULL)
+  - batch_id (UUID NOT NULL)
+  - name (TEXT NULL)
+  - custom_data (JSONB NULL)
+  - status (TEXT NOT NULL DEFAULT 'PENDING')
+  - total_count (INT NOT NULL DEFAULT 0)
+  - completed_count (INT NOT NULL DEFAULT 0)
+  - canceled_count (INT NOT NULL DEFAULT 0)
+  - in_troubleshooting_count (INT NOT NULL DEFAULT 0)
+  - created_at (TIMESTAMPTZ NOT NULL DEFAULT NOW())
+  - started_at (TIMESTAMPTZ NULL)
+  - completed_at (TIMESTAMPTZ NULL)
+**And** primary key is (domain, batch_id)
+
+## Test Mapping
+
+| Criterion | Test Type | Test Location |
+|-----------|-----------|---------------|
+| Schema created | Integration | `tests/integration/test_migrations.py::test_v001_creates_schema` |
+| Tables exist | Integration | `tests/integration/test_migrations.py::test_v001_creates_tables` |
+| SPs exist | Integration | `tests/integration/test_migrations.py::test_v001_creates_stored_procedures` |
+| Idempotent | Integration | `tests/integration/test_migrations.py::test_migrations_idempotent` |
+
+## Story Size
+
+L (4000-8000 tokens, large feature - many SQL objects to create)
+
+## Priority (MoSCoW)
+
+Must Have
+
+## Dependencies
+
+- PostgreSQL with PGMQ extension
+- Flyway migration tool configured
+
+## Technical Notes
+
+- Use `CREATE SCHEMA IF NOT EXISTS commandbus;`
+- Set `search_path` at start of migration for convenience
+- Copy all current content from `scripts/init-db.sql`
+- Rename tables: `command_bus_X` -> `commandbus.X`
+- Ensure stored procedures use schema-qualified table names
+- PGMQ tables remain in `pgmq` schema (managed by extension)
+
+## Files to Create/Modify
+
+**Create:**
+- `migrations/V001__commandbus_schema.sql` - Full schema migration
+
+**Reference (copy from):**
+- `scripts/init-db.sql` - Current table definitions and stored procedures
+
+## Verification Steps
+
+1. Run `docker compose down -v` to clear existing data
+2. Run Flyway migration
+3. Verify schema: `\dn` should show `commandbus`
+4. Verify tables: `\dt commandbus.*` should list all tables
+5. Verify functions: `\df commandbus.*` should list all stored procedures
+
+## Definition of Done
+
+- [ ] V001 migration file created
+- [ ] All tables created in commandbus schema
+- [ ] All stored procedures created in commandbus schema
+- [ ] All indexes created
+- [ ] Migration tested on fresh database
+- [ ] Migration tested on existing database (idempotent)

--- a/docs/features/stories/S047-e2e-schema-migration.md
+++ b/docs/features/stories/S047-e2e-schema-migration.md
@@ -1,0 +1,107 @@
+# S047: Create E2E Test Schema (V2 Migration)
+
+## Parent Feature
+
+[F010 - Database Schema Management](../F010-database-schema-management.md)
+
+## User Story
+
+**As a** test engineer
+**I want** E2E test tables isolated in a dedicated `e2e` schema
+**So that** test infrastructure is clearly separated from production command bus tables
+
+## Context
+
+The E2E testing framework uses tables like `test_command` and `e2e_config` to control test behavior. These should not be in the public schema or mixed with command bus tables. This story creates a V2 migration that sets up the `e2e` schema with all test-specific tables.
+
+## Acceptance Criteria (Given-When-Then)
+
+### Scenario: Create e2e schema with test tables
+
+**Given** the V001 migration (commandbus schema) has run
+**When** the V002 migration runs
+**Then** the `e2e` schema is created
+**And** the following tables exist in `e2e` schema:
+  - `e2e.test_command` (test behavior specifications)
+  - `e2e.config` (worker/retry configuration)
+
+### Scenario: Test command table structure
+
+**Given** the V002 migration has run
+**When** I describe the `e2e.test_command` table
+**Then** it has columns:
+  - id (SERIAL PRIMARY KEY)
+  - command_id (UUID NOT NULL UNIQUE)
+  - payload (JSONB NOT NULL DEFAULT '{}')
+  - behavior (JSONB NOT NULL)
+  - created_at (TIMESTAMPTZ DEFAULT NOW())
+  - processed_at (TIMESTAMPTZ NULL)
+  - attempts (INTEGER DEFAULT 0)
+  - result (JSONB NULL)
+**And** indexes exist on command_id and created_at
+
+### Scenario: Config table with defaults
+
+**Given** the V002 migration has run
+**When** I query `e2e.config`
+**Then** it contains default rows:
+  - key='worker': visibility_timeout, concurrency, poll_interval, batch_size
+  - key='retry': max_attempts, base_delay_ms, max_delay_ms, backoff_multiplier
+
+### Scenario: E2E schema is optional
+
+**Given** the V001 migration has run
+**And** V002 migration is not applied
+**When** the command bus application starts
+**Then** it operates normally (e2e tables not required for production)
+
+## Test Mapping
+
+| Criterion | Test Type | Test Location |
+|-----------|-----------|---------------|
+| Schema created | Integration | `tests/integration/test_migrations.py::test_v002_creates_e2e_schema` |
+| Tables exist | Integration | `tests/integration/test_migrations.py::test_v002_creates_e2e_tables` |
+| Default config | Integration | `tests/integration/test_migrations.py::test_v002_inserts_default_config` |
+
+## Story Size
+
+S (1000-2000 tokens, small feature)
+
+## Priority (MoSCoW)
+
+Should Have
+
+## Dependencies
+
+- S046 (V001 commandbus schema) completed
+- Flyway migration tool configured
+
+## Technical Notes
+
+- Use `CREATE SCHEMA IF NOT EXISTS e2e;`
+- Copy table definitions from existing `tests/e2e/migrations/V004__test_command_table.sql`
+- Insert default config values
+- This migration is optional for production deployments
+
+## Files to Create/Modify
+
+**Create:**
+- `migrations/V002__e2e_schema.sql` - E2E test schema migration
+
+**Reference (copy from):**
+- `tests/e2e/migrations/V004__test_command_table.sql` - Current table definitions
+
+## Verification Steps
+
+1. Run V001 and V002 migrations
+2. Verify schema: `\dn` should show both `commandbus` and `e2e`
+3. Verify tables: `\dt e2e.*` should list test_command and config
+4. Verify config: `SELECT * FROM e2e.config` should return 2 rows
+
+## Definition of Done
+
+- [ ] V002 migration file created
+- [ ] e2e schema created
+- [ ] test_command table with correct structure
+- [ ] config table with default values
+- [ ] Migration tested

--- a/docs/features/stories/S048-docker-flyway-integration.md
+++ b/docs/features/stories/S048-docker-flyway-integration.md
@@ -1,0 +1,142 @@
+# S048: Update Docker Compose for Flyway Migrations
+
+## Parent Feature
+
+[F010 - Database Schema Management](../F010-database-schema-management.md)
+
+## User Story
+
+**As a** developer
+**I want** Docker Compose to automatically run Flyway migrations on startup
+**So that** my local development environment always has the correct schema
+
+## Context
+
+Currently, Docker Compose uses `scripts/init-db.sql` which runs only on fresh database creation. This story updates the Docker setup to use Flyway migrations, ensuring the same migration process is used across development, testing, and production environments.
+
+## Acceptance Criteria (Given-When-Then)
+
+### Scenario: Fresh database initialization
+
+**Given** no Docker volumes exist
+**When** I run `docker compose up -d`
+**Then** PostgreSQL starts
+**And** Flyway runs all migrations (V001, V002, ...)
+**And** both `commandbus` and `e2e` schemas exist
+**And** all tables and stored procedures are created
+
+### Scenario: Existing database with new migration
+
+**Given** Docker volumes exist with V001 applied
+**And** a new V003 migration file is added
+**When** I run `docker compose up -d`
+**Then** Flyway runs only the new V003 migration
+**And** existing data is preserved
+
+### Scenario: Migration failure handling
+
+**Given** a migration file has a syntax error
+**When** I run `docker compose up -d`
+**Then** Flyway reports the error
+**And** the container exits with non-zero status
+**And** the database is left in a consistent state
+
+### Scenario: Clean rebuild
+
+**Given** Docker volumes exist
+**When** I run `docker compose down -v && docker compose up -d`
+**Then** all volumes are removed
+**And** Flyway runs all migrations from scratch
+**And** the database is freshly initialized
+
+### Scenario: Make targets still work
+
+**Given** docker-compose.yml is updated
+**When** I run `make docker-up`
+**Then** the database starts with migrations applied
+**When** I run `make test-integration`
+**Then** integration tests pass against the migrated schema
+
+## Test Mapping
+
+| Criterion | Test Type | Test Location |
+|-----------|-----------|---------------|
+| Fresh init | Manual | Run `docker compose down -v && docker compose up` |
+| Schema exists | Manual | `docker compose exec postgres psql -c '\dn'` |
+| Migrations recorded | Manual | `SELECT * FROM flyway_schema_history` |
+
+## Story Size
+
+M (2000-4000 tokens, medium complexity)
+
+## Priority (MoSCoW)
+
+Must Have
+
+## Dependencies
+
+- S046 (V001 commandbus schema) completed
+- S047 (V002 e2e schema) completed
+
+## Technical Notes
+
+### Option A: Flyway Container (Recommended)
+Add a Flyway service to docker-compose.yml:
+
+```yaml
+services:
+  flyway:
+    image: flyway/flyway:10
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ./migrations:/flyway/sql
+    command: migrate
+    environment:
+      FLYWAY_URL: jdbc:postgresql://postgres:5432/commandbus
+      FLYWAY_USER: postgres
+      FLYWAY_PASSWORD: postgres
+```
+
+### Option B: Init Script with Flyway
+Use a custom entrypoint script that runs Flyway before starting PostgreSQL.
+
+### Changes Required
+
+1. Create `migrations/` directory at project root
+2. Move/create V001 and V002 migration files
+3. Update `docker-compose.yml` to add Flyway service
+4. Remove or deprecate `scripts/init-db.sql`
+5. Update Makefile if needed
+
+## Files to Create/Modify
+
+**Create:**
+- `migrations/` directory structure
+
+**Modify:**
+- `docker-compose.yml` - Add Flyway service
+- `Makefile` - Update docker-up target if needed
+
+**Deprecate:**
+- `scripts/init-db.sql` - Mark as deprecated or remove
+
+## Verification Steps
+
+1. Run `docker compose down -v` to clean up
+2. Run `docker compose up -d`
+3. Check Flyway output: `docker compose logs flyway`
+4. Verify schemas: `docker compose exec postgres psql -U postgres -d commandbus -c '\dn'`
+5. Verify tables: `docker compose exec postgres psql -U postgres -d commandbus -c '\dt commandbus.*'`
+6. Run `make test-integration` to verify tests pass
+
+## Definition of Done
+
+- [ ] migrations/ directory created with V001, V002
+- [ ] docker-compose.yml updated with Flyway service
+- [ ] Fresh database init works via `docker compose up`
+- [ ] Incremental migrations work
+- [ ] Integration tests pass
+- [ ] scripts/init-db.sql deprecated or removed
+- [ ] Makefile targets still work

--- a/docs/features/stories/S049-python-schema-qualified-names.md
+++ b/docs/features/stories/S049-python-schema-qualified-names.md
@@ -1,0 +1,154 @@
+# S049: Update Python Code for Schema-Qualified Names
+
+## Parent Feature
+
+[F010 - Database Schema Management](../F010-database-schema-management.md)
+
+## User Story
+
+**As a** developer
+**I want** Python repository classes to use schema-qualified table names
+**So that** the code works correctly with the new `commandbus` schema
+
+## Context
+
+After migrating tables to the `commandbus` schema, all SQL queries in the Python code need to reference tables using schema-qualified names (e.g., `commandbus.command` instead of `command_bus_command`). This story updates all repository classes and stored procedure calls.
+
+## Acceptance Criteria (Given-When-Then)
+
+### Scenario: Command repository uses schema-qualified names
+
+**Given** the commandbus schema exists with all tables
+**When** I call `command_repo.get(domain, command_id)`
+**Then** the query references `commandbus.command` table
+**And** the command metadata is returned correctly
+
+### Scenario: Batch repository uses schema-qualified names
+
+**Given** the commandbus schema exists
+**When** I call `batch_repo.create(domain, batch_id, ...)`
+**Then** the query references `commandbus.batch` table
+**And** the batch is created correctly
+
+### Scenario: Stored procedure calls use schema-qualified names
+
+**Given** the commandbus schema exists with stored procedures
+**When** I call `command_repo.sp_finish_command(...)`
+**Then** it calls `commandbus.sp_finish_command`
+**And** the command is updated correctly
+
+### Scenario: Audit repository uses schema-qualified names
+
+**Given** the commandbus schema exists
+**When** I call `audit_logger.log(...)`
+**Then** the query references `commandbus.audit` table
+**And** the audit event is recorded
+
+### Scenario: Troubleshooting queue uses schema-qualified names
+
+**Given** the commandbus schema exists
+**When** I call `tsq.list_troubleshooting(domain)`
+**Then** queries reference `commandbus.command` and PGMQ archive tables
+**And** results are returned correctly
+
+### Scenario: All existing tests pass
+
+**Given** all repository classes are updated
+**When** I run `make test-integration`
+**Then** all integration tests pass
+
+## Test Mapping
+
+| Criterion | Test Type | Test Location |
+|-----------|-----------|---------------|
+| Command operations | Integration | `tests/integration/test_worker.py` |
+| Batch operations | Integration | `tests/integration/test_batch.py` |
+| TSQ operations | Integration | `tests/integration/test_troubleshooting_queue.py` |
+| Query operations | Integration | `tests/integration/test_query.py` |
+
+## Story Size
+
+M (2000-4000 tokens, many files to update but mechanical changes)
+
+## Priority (MoSCoW)
+
+Must Have
+
+## Dependencies
+
+- S046 (V001 commandbus schema) completed
+- S048 (Docker Flyway integration) completed
+
+## Technical Notes
+
+### Approach: Schema-Qualified Names
+
+Update all table references to use explicit schema:
+- `command_bus_command` -> `commandbus.command`
+- `command_bus_batch` -> `commandbus.batch`
+- `command_bus_audit` -> `commandbus.audit`
+- `command_bus_payload_archive` -> `commandbus.payload_archive`
+
+Update all stored procedure calls:
+- `sp_receive_command` -> `commandbus.sp_receive_command`
+- `sp_finish_command` -> `commandbus.sp_finish_command`
+- etc.
+
+### Alternative: search_path
+
+Could set `search_path = commandbus, pgmq, public` on connections instead. This is less explicit but requires fewer code changes.
+
+**Decision:** Use schema-qualified names for explicitness and clarity.
+
+### Files to Modify
+
+1. `src/commandbus/repositories/command.py`
+   - Update all table references
+   - Update stored procedure calls
+
+2. `src/commandbus/repositories/batch.py`
+   - Update all table references
+   - Update stored procedure calls
+
+3. `src/commandbus/repositories/audit.py`
+   - Update table reference
+
+4. `src/commandbus/ops/troubleshooting.py`
+   - Update table references
+
+5. `src/commandbus/ops/query.py`
+   - Update table references
+
+### Constants Approach
+
+Consider defining table names as constants:
+
+```python
+# src/commandbus/constants.py
+SCHEMA = "commandbus"
+TABLE_COMMAND = f"{SCHEMA}.command"
+TABLE_BATCH = f"{SCHEMA}.batch"
+TABLE_AUDIT = f"{SCHEMA}.audit"
+SP_RECEIVE_COMMAND = f"{SCHEMA}.sp_receive_command"
+# etc.
+```
+
+## Verification Steps
+
+1. Update all repository files
+2. Run `make typecheck` - should pass
+3. Run `make lint` - should pass
+4. Run `make docker-up` - apply migrations
+5. Run `make test-integration` - all tests should pass
+6. Run `make test` - all unit tests should pass
+
+## Definition of Done
+
+- [ ] All repository classes updated with schema-qualified names
+- [ ] All stored procedure calls updated
+- [ ] Constants file created (optional but recommended)
+- [ ] Type checking passes
+- [ ] Linting passes
+- [ ] Unit tests pass
+- [ ] Integration tests pass
+- [ ] No regressions

--- a/docs/features/stories/S050-cleanup-legacy-migrations.md
+++ b/docs/features/stories/S050-cleanup-legacy-migrations.md
@@ -1,0 +1,131 @@
+# S050: Clean Up Legacy Migrations and E2E Test Infrastructure
+
+## Parent Feature
+
+[F010 - Database Schema Management](../F010-database-schema-management.md)
+
+## User Story
+
+**As a** maintainer
+**I want** to remove outdated migration files and update E2E test infrastructure
+**So that** there is a single, consistent migration path for all environments
+
+## Context
+
+The `tests/e2e/migrations/` directory contains outdated Flyway migrations (V001-V004) that are missing batch support and stored procedures. This story cleans up these legacy files, updates the E2E test infrastructure to use the new centralized migrations, and ensures all test environments use the same schema.
+
+## Acceptance Criteria (Given-When-Then)
+
+### Scenario: Remove legacy e2e migrations
+
+**Given** `tests/e2e/migrations/` contains V001-V004 files
+**When** I complete this story
+**Then** the legacy migration files are removed
+**And** E2E tests use the centralized `migrations/` directory
+
+### Scenario: E2E tests use new schema
+
+**Given** the centralized migrations are applied
+**When** E2E tests run
+**Then** they reference `commandbus.command` (not `command_bus_command`)
+**And** they reference `e2e.test_command` (not `test_command`)
+**And** all tests pass
+
+### Scenario: E2E app code updated
+
+**Given** the E2E app uses test_command table
+**When** I update the E2E app code
+**Then** it references `e2e.test_command`
+**And** it references `e2e.config`
+**And** the E2E app works correctly
+
+### Scenario: Flyway configuration updated
+
+**Given** tests/e2e uses Flyway
+**When** Flyway runs
+**Then** it uses the centralized `migrations/` directory
+**And** migrations are applied correctly
+
+### Scenario: Integration tests work with new schema
+
+**Given** integration tests exist
+**When** I run `make test-integration`
+**Then** all tests pass with the new schema
+**And** no references to old table names remain
+
+## Test Mapping
+
+| Criterion | Test Type | Test Location |
+|-----------|-----------|---------------|
+| E2E tests pass | E2E | `tests/e2e/` |
+| Integration tests pass | Integration | `tests/integration/` |
+| Schema references correct | Manual | Code review |
+
+## Story Size
+
+M (2000-4000 tokens, cleanup and updates across multiple files)
+
+## Priority (MoSCoW)
+
+Must Have
+
+## Dependencies
+
+- S046 (V001 commandbus schema) completed
+- S047 (V002 e2e schema) completed
+- S048 (Docker Flyway integration) completed
+- S049 (Python schema-qualified names) completed
+
+## Technical Notes
+
+### Files to Remove
+
+```
+tests/e2e/migrations/
+├── V001__pgmq_extension.sql      # Remove (PGMQ in V001)
+├── V002__commandbus_schema.sql   # Remove (outdated, replaced by V001)
+├── V003__pgmq_queues.sql         # Remove (handled elsewhere)
+└── V004__test_command_table.sql  # Remove (replaced by V002 e2e schema)
+```
+
+### Files to Update
+
+1. **`tests/e2e/flyway.conf`** (or equivalent)
+   - Point to centralized `migrations/` directory
+
+2. **`tests/e2e/app/` Python files**
+   - Update table references to `e2e.test_command`, `e2e.config`
+
+3. **`tests/e2e/docker-compose.yml`** (if exists)
+   - Update Flyway configuration
+
+4. **Integration test fixtures**
+   - Ensure they work with new schema names
+
+### Search Path Alternative
+
+If E2E app sets `search_path = commandbus, e2e, pgmq, public`, fewer code changes needed. Consider this approach for E2E code.
+
+## Verification Steps
+
+1. Remove legacy migration files
+2. Update E2E Flyway configuration
+3. Update E2E app code for new table names
+4. Run `make docker-up` - verify migrations apply
+5. Run `make test-integration` - all should pass
+6. Run E2E tests - all should pass
+7. Verify no references to old table names remain:
+   ```bash
+   grep -r "command_bus_command" tests/
+   grep -r "command_bus_batch" tests/
+   ```
+
+## Definition of Done
+
+- [ ] Legacy `tests/e2e/migrations/` files removed
+- [ ] E2E Flyway config points to centralized migrations
+- [ ] E2E app code updated for new schema names
+- [ ] Integration tests pass
+- [ ] E2E tests pass
+- [ ] No references to old table names in codebase
+- [ ] Documentation updated

--- a/migrations/V001__commandbus_schema.sql
+++ b/migrations/V001__commandbus_schema.sql
@@ -1,0 +1,518 @@
+-- V001: Command Bus Core Schema
+-- Creates the 'commandbus' schema with all core tables and stored procedures
+--
+-- This migration consolidates all command bus database objects into a dedicated schema
+-- for better organization and separation of concerns.
+
+-- Enable PGMQ extension (required for message queuing)
+CREATE EXTENSION IF NOT EXISTS pgmq;
+
+-- Create commandbus schema
+CREATE SCHEMA IF NOT EXISTS commandbus;
+
+-- Set search path for this migration
+SET search_path TO commandbus, pgmq, public;
+
+-- ============================================================================
+-- Tables
+-- ============================================================================
+
+-- Batch table (must be created before command table for FK reference)
+CREATE TABLE IF NOT EXISTS commandbus.batch (
+    domain                    TEXT NOT NULL,
+    batch_id                  UUID NOT NULL,
+    name                      TEXT NULL,
+    custom_data               JSONB NULL,
+    status                    TEXT NOT NULL DEFAULT 'PENDING',
+    total_count               INT NOT NULL DEFAULT 0,
+    completed_count           INT NOT NULL DEFAULT 0,
+    canceled_count            INT NOT NULL DEFAULT 0,
+    in_troubleshooting_count  INT NOT NULL DEFAULT 0,
+    created_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    started_at                TIMESTAMPTZ NULL,
+    completed_at              TIMESTAMPTZ NULL,
+    PRIMARY KEY (domain, batch_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_batch_status
+    ON commandbus.batch(domain, status);
+
+CREATE INDEX IF NOT EXISTS ix_batch_created
+    ON commandbus.batch(domain, created_at DESC);
+
+-- Command table (command metadata)
+CREATE TABLE IF NOT EXISTS commandbus.command (
+    domain            TEXT NOT NULL,
+    queue_name        TEXT NOT NULL,
+    msg_id            BIGINT NULL,
+    command_id        UUID NOT NULL,
+    command_type      TEXT NOT NULL,
+    status            TEXT NOT NULL,
+    attempts          INT NOT NULL DEFAULT 0,
+    max_attempts      INT NOT NULL,
+    lease_expires_at  TIMESTAMPTZ NULL,
+    last_error_type   TEXT NULL,
+    last_error_code   TEXT NULL,
+    last_error_msg    TEXT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    reply_queue       TEXT NOT NULL DEFAULT '',
+    correlation_id    UUID NULL,
+    batch_id          UUID NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_command_domain_cmdid
+    ON commandbus.command(domain, command_id);
+
+CREATE INDEX IF NOT EXISTS ix_command_status_type
+    ON commandbus.command(status, command_type);
+
+CREATE INDEX IF NOT EXISTS ix_command_status_created
+    ON commandbus.command(status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS ix_command_updated
+    ON commandbus.command(updated_at);
+
+CREATE INDEX IF NOT EXISTS ix_command_batch
+    ON commandbus.command(domain, batch_id) WHERE batch_id IS NOT NULL;
+
+-- Audit table (append-only)
+CREATE TABLE IF NOT EXISTS commandbus.audit (
+    audit_id      BIGSERIAL PRIMARY KEY,
+    domain        TEXT NOT NULL,
+    command_id    UUID NOT NULL,
+    event_type    TEXT NOT NULL,
+    ts            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    details_json  JSONB NULL
+);
+
+CREATE INDEX IF NOT EXISTS ix_audit_cmdid_ts
+    ON commandbus.audit(command_id, ts);
+
+-- Optional payload archive
+CREATE TABLE IF NOT EXISTS commandbus.payload_archive (
+    domain        TEXT NOT NULL,
+    command_id    UUID NOT NULL,
+    payload_json  JSONB NOT NULL,
+    archived_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY(domain, command_id)
+);
+
+
+-- ============================================================================
+-- Stored Procedures
+-- These combine command + audit operations into single DB calls for performance
+-- ============================================================================
+
+-- sp_receive_command: Atomically receive a command
+-- Combines: get metadata + increment attempts + update status + insert audit + start batch
+-- Returns NULL if command not found or in terminal state
+CREATE OR REPLACE FUNCTION commandbus.sp_receive_command(
+    p_domain TEXT,
+    p_command_id UUID,
+    p_new_status TEXT DEFAULT 'IN_PROGRESS',
+    p_msg_id BIGINT DEFAULT NULL,
+    p_max_attempts INT DEFAULT NULL
+) RETURNS TABLE (
+    domain TEXT,
+    command_id UUID,
+    command_type TEXT,
+    status TEXT,
+    attempts INT,
+    max_attempts INT,
+    msg_id BIGINT,
+    correlation_id UUID,
+    reply_queue TEXT,
+    last_error_type TEXT,
+    last_error_code TEXT,
+    last_error_msg TEXT,
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ,
+    batch_id UUID
+) AS $$
+DECLARE
+    v_attempts INT;
+    v_max_attempts INT;
+    v_command_type TEXT;
+    v_status TEXT;
+    v_msg_id BIGINT;
+    v_correlation_id UUID;
+    v_reply_queue TEXT;
+    v_last_error_type TEXT;
+    v_last_error_code TEXT;
+    v_last_error_msg TEXT;
+    v_created_at TIMESTAMPTZ;
+    v_updated_at TIMESTAMPTZ;
+    v_batch_id UUID;
+BEGIN
+    -- Atomically update and get command metadata
+    UPDATE commandbus.command c
+    SET attempts = c.attempts + 1,
+        status = p_new_status,
+        updated_at = NOW()
+    WHERE c.domain = p_domain
+      AND c.command_id = p_command_id
+      AND c.status NOT IN ('COMPLETED', 'CANCELED')
+    RETURNING
+        c.command_type, c.status, c.attempts, c.max_attempts, c.msg_id,
+        c.correlation_id, c.reply_queue, c.last_error_type, c.last_error_code,
+        c.last_error_msg, c.created_at, c.updated_at, c.batch_id
+    INTO
+        v_command_type, v_status, v_attempts, v_max_attempts, v_msg_id,
+        v_correlation_id, v_reply_queue, v_last_error_type, v_last_error_code,
+        v_last_error_msg, v_created_at, v_updated_at, v_batch_id;
+
+    -- If no row updated, command not found or in terminal state
+    IF NOT FOUND THEN
+        RETURN;
+    END IF;
+
+    -- Insert audit event
+    INSERT INTO commandbus.audit (domain, command_id, event_type, details_json)
+    VALUES (
+        p_domain,
+        p_command_id,
+        'RECEIVED',
+        jsonb_build_object(
+            'msg_id', COALESCE(p_msg_id, v_msg_id),
+            'attempt', v_attempts,
+            'max_attempts', COALESCE(p_max_attempts, v_max_attempts)
+        )
+    );
+
+    -- Start batch if this command belongs to one (transitions PENDING -> IN_PROGRESS)
+    IF v_batch_id IS NOT NULL THEN
+        PERFORM commandbus.sp_start_batch(p_domain, v_batch_id);
+    END IF;
+
+    -- Return the metadata
+    RETURN QUERY SELECT
+        p_domain,
+        p_command_id,
+        v_command_type,
+        v_status,
+        v_attempts,
+        COALESCE(p_max_attempts, v_max_attempts),
+        COALESCE(p_msg_id, v_msg_id),
+        v_correlation_id,
+        v_reply_queue,
+        v_last_error_type,
+        v_last_error_code,
+        v_last_error_msg,
+        v_created_at,
+        v_updated_at,
+        v_batch_id;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- sp_finish_command: Atomically finish a command (success or failure)
+-- Combines: update status/error + insert audit + update batch counters
+-- Returns is_batch_complete (TRUE if batch is now complete, for callback triggering)
+CREATE OR REPLACE FUNCTION commandbus.sp_finish_command(
+    p_domain TEXT,
+    p_command_id UUID,
+    p_status TEXT,
+    p_event_type TEXT,
+    p_error_type TEXT DEFAULT NULL,
+    p_error_code TEXT DEFAULT NULL,
+    p_error_msg TEXT DEFAULT NULL,
+    p_details JSONB DEFAULT NULL,
+    p_batch_id UUID DEFAULT NULL
+) RETURNS BOOLEAN AS $$
+DECLARE
+    v_found BOOLEAN;
+    v_is_batch_complete BOOLEAN := FALSE;
+    v_update_type TEXT;
+BEGIN
+    -- Update command metadata
+    UPDATE commandbus.command
+    SET status = p_status,
+        last_error_type = COALESCE(p_error_type, last_error_type),
+        last_error_code = COALESCE(p_error_code, last_error_code),
+        last_error_msg = COALESCE(p_error_msg, last_error_msg),
+        updated_at = NOW()
+    WHERE domain = p_domain AND command_id = p_command_id;
+
+    v_found := FOUND;
+
+    -- Insert audit event (even if command not found, for debugging)
+    INSERT INTO commandbus.audit (domain, command_id, event_type, details_json)
+    VALUES (p_domain, p_command_id, p_event_type, p_details);
+
+    -- Update batch counters if this command belongs to a batch
+    IF p_batch_id IS NOT NULL AND v_found THEN
+        -- Determine update_type based on status
+        CASE p_status
+            WHEN 'COMPLETED' THEN
+                v_update_type := 'complete';
+            WHEN 'IN_TROUBLESHOOTING_QUEUE' THEN
+                v_update_type := 'tsq_move';
+            ELSE
+                v_update_type := NULL;  -- No batch update for other statuses
+        END CASE;
+
+        IF v_update_type IS NOT NULL THEN
+            v_is_batch_complete := commandbus.sp_update_batch_counters(p_domain, p_batch_id, v_update_type);
+        END IF;
+    END IF;
+
+    RETURN v_is_batch_complete;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- sp_fail_command: Handle transient failure with error update + audit
+-- Used for retryable failures (before exhaustion)
+CREATE OR REPLACE FUNCTION commandbus.sp_fail_command(
+    p_domain TEXT,
+    p_command_id UUID,
+    p_error_type TEXT,
+    p_error_code TEXT,
+    p_error_msg TEXT,
+    p_attempt INT,
+    p_max_attempts INT,
+    p_msg_id BIGINT
+) RETURNS BOOLEAN AS $$
+BEGIN
+    -- Update error info
+    UPDATE commandbus.command
+    SET last_error_type = p_error_type,
+        last_error_code = p_error_code,
+        last_error_msg = p_error_msg,
+        updated_at = NOW()
+    WHERE domain = p_domain AND command_id = p_command_id;
+
+    IF NOT FOUND THEN
+        RETURN FALSE;
+    END IF;
+
+    -- Insert audit event
+    INSERT INTO commandbus.audit (domain, command_id, event_type, details_json)
+    VALUES (
+        p_domain,
+        p_command_id,
+        'FAILED',
+        jsonb_build_object(
+            'msg_id', p_msg_id,
+            'attempt', p_attempt,
+            'max_attempts', p_max_attempts,
+            'error_type', p_error_type,
+            'error_code', p_error_code,
+            'error_msg', p_error_msg
+        )
+    );
+
+    RETURN TRUE;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- ============================================================================
+-- Batch Status Tracking Stored Procedures
+-- Consolidated batch counter updates with is_batch_complete return value
+-- ============================================================================
+
+-- sp_update_batch_counters: Central helper for updating batch counters
+-- Called from sp_finish_command and TSQ operations
+-- Returns TRUE if batch is now complete (for callback triggering)
+--
+-- update_type values:
+--   'complete'     - Command completed successfully (completed_count++)
+--   'tsq_move'     - Command moved to TSQ (in_troubleshooting_count++)
+--   'tsq_complete' - Operator completed from TSQ (in_troubleshooting_count--, completed_count++)
+--   'tsq_cancel'   - Operator canceled from TSQ (in_troubleshooting_count--, canceled_count++)
+--   'tsq_retry'    - Operator retried from TSQ (in_troubleshooting_count--)
+CREATE OR REPLACE FUNCTION commandbus.sp_update_batch_counters(
+    p_domain TEXT,
+    p_batch_id UUID,
+    p_update_type TEXT
+) RETURNS BOOLEAN AS $$
+DECLARE
+    v_batch RECORD;
+    v_is_complete BOOLEAN := FALSE;
+BEGIN
+    IF p_batch_id IS NULL THEN
+        RETURN FALSE;
+    END IF;
+
+    -- Update counters based on update_type
+    CASE p_update_type
+        WHEN 'complete' THEN
+            UPDATE commandbus.batch
+            SET completed_count = completed_count + 1
+            WHERE domain = p_domain AND batch_id = p_batch_id
+            RETURNING * INTO v_batch;
+
+        WHEN 'tsq_move' THEN
+            UPDATE commandbus.batch
+            SET in_troubleshooting_count = in_troubleshooting_count + 1
+            WHERE domain = p_domain AND batch_id = p_batch_id
+            RETURNING * INTO v_batch;
+
+        WHEN 'tsq_complete' THEN
+            UPDATE commandbus.batch
+            SET in_troubleshooting_count = in_troubleshooting_count - 1,
+                completed_count = completed_count + 1
+            WHERE domain = p_domain AND batch_id = p_batch_id
+            RETURNING * INTO v_batch;
+
+        WHEN 'tsq_cancel' THEN
+            UPDATE commandbus.batch
+            SET in_troubleshooting_count = in_troubleshooting_count - 1,
+                canceled_count = canceled_count + 1
+            WHERE domain = p_domain AND batch_id = p_batch_id
+            RETURNING * INTO v_batch;
+
+        WHEN 'tsq_retry' THEN
+            UPDATE commandbus.batch
+            SET in_troubleshooting_count = in_troubleshooting_count - 1
+            WHERE domain = p_domain AND batch_id = p_batch_id
+            RETURNING * INTO v_batch;
+
+        ELSE
+            RAISE EXCEPTION 'Unknown update_type: %', p_update_type;
+    END CASE;
+
+    IF v_batch IS NULL THEN
+        RETURN FALSE;
+    END IF;
+
+    -- Check if batch is now complete (all commands in terminal state, none in TSQ)
+    -- Batch completion formula: completed + canceled = total AND in_tsq = 0
+    IF v_batch.completed_count + v_batch.canceled_count = v_batch.total_count
+       AND v_batch.in_troubleshooting_count = 0 THEN
+        v_is_complete := TRUE;
+
+        -- Determine final status
+        IF v_batch.canceled_count > 0 THEN
+            UPDATE commandbus.batch
+            SET status = 'COMPLETED_WITH_FAILURES',
+                completed_at = NOW()
+            WHERE domain = p_domain AND batch_id = p_batch_id;
+        ELSE
+            UPDATE commandbus.batch
+            SET status = 'COMPLETED',
+                completed_at = NOW()
+            WHERE domain = p_domain AND batch_id = p_batch_id;
+        END IF;
+
+        -- Record audit event for batch completion
+        INSERT INTO commandbus.audit (domain, command_id, event_type, details_json)
+        VALUES (
+            p_domain,
+            p_batch_id,
+            'BATCH_COMPLETED',
+            jsonb_build_object(
+                'batch_id', p_batch_id,
+                'total_count', v_batch.total_count,
+                'completed_count', v_batch.completed_count,
+                'canceled_count', v_batch.canceled_count
+            )
+        );
+    END IF;
+
+    RETURN v_is_complete;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- sp_start_batch: Transition batch from PENDING to IN_PROGRESS on first command receive
+-- Called from sp_receive_command when a batched command is first processed
+CREATE OR REPLACE FUNCTION commandbus.sp_start_batch(
+    p_domain TEXT,
+    p_batch_id UUID
+) RETURNS BOOLEAN AS $$
+DECLARE
+    v_batch RECORD;
+BEGIN
+    IF p_batch_id IS NULL THEN
+        RETURN FALSE;
+    END IF;
+
+    -- Lock the batch row and check if it's still PENDING
+    SELECT * INTO v_batch
+    FROM commandbus.batch
+    WHERE domain = p_domain AND batch_id = p_batch_id
+    FOR UPDATE;
+
+    IF v_batch IS NULL THEN
+        RETURN FALSE;
+    END IF;
+
+    -- Only transition from PENDING to IN_PROGRESS
+    IF v_batch.status = 'PENDING' THEN
+        UPDATE commandbus.batch
+        SET status = 'IN_PROGRESS',
+            started_at = NOW()
+        WHERE domain = p_domain AND batch_id = p_batch_id;
+
+        -- Record audit event for batch start
+        INSERT INTO commandbus.audit (domain, command_id, event_type, details_json)
+        VALUES (
+            p_domain,
+            p_batch_id,  -- Use batch_id as command_id for batch events
+            'BATCH_STARTED',
+            jsonb_build_object('batch_id', p_batch_id)
+        );
+
+        RETURN TRUE;
+    END IF;
+
+    RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- ============================================================================
+-- Troubleshooting Queue (TSQ) Stored Procedures
+-- These are called by operators to complete/cancel/retry commands from TSQ
+-- They return is_batch_complete for callback triggering
+-- ============================================================================
+
+-- sp_tsq_complete: Operator completes a command from TSQ
+-- Returns is_batch_complete flag for callback triggering
+CREATE OR REPLACE FUNCTION commandbus.sp_tsq_complete(
+    p_domain TEXT,
+    p_batch_id UUID
+) RETURNS BOOLEAN AS $$
+BEGIN
+    IF p_batch_id IS NULL THEN
+        RETURN FALSE;
+    END IF;
+    RETURN commandbus.sp_update_batch_counters(p_domain, p_batch_id, 'tsq_complete');
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- sp_tsq_cancel: Operator cancels a command from TSQ
+-- Returns is_batch_complete flag for callback triggering
+CREATE OR REPLACE FUNCTION commandbus.sp_tsq_cancel(
+    p_domain TEXT,
+    p_batch_id UUID
+) RETURNS BOOLEAN AS $$
+BEGIN
+    IF p_batch_id IS NULL THEN
+        RETURN FALSE;
+    END IF;
+    RETURN commandbus.sp_update_batch_counters(p_domain, p_batch_id, 'tsq_cancel');
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- sp_tsq_retry: Operator retries a command from TSQ
+-- Note: Retry never completes a batch (command goes back to queue)
+-- Returns FALSE always since retry cannot complete a batch
+CREATE OR REPLACE FUNCTION commandbus.sp_tsq_retry(
+    p_domain TEXT,
+    p_batch_id UUID
+) RETURNS BOOLEAN AS $$
+BEGIN
+    IF p_batch_id IS NULL THEN
+        RETURN FALSE;
+    END IF;
+    -- sp_update_batch_counters will always return FALSE for tsq_retry
+    -- because it decrements in_troubleshooting_count without adding to terminal counts
+    RETURN commandbus.sp_update_batch_counters(p_domain, p_batch_id, 'tsq_retry');
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

- Create `migrations/` directory with Flyway V001 migration file
- Add `commandbus` schema with all core tables:
  - `commandbus.batch` - Batch tracking
  - `commandbus.command` - Command metadata
  - `commandbus.audit` - Audit events
  - `commandbus.payload_archive` - Archived payloads
- Add all stored procedures in commandbus schema:
  - `sp_receive_command` - Atomically receive a command
  - `sp_finish_command` - Complete or fail a command
  - `sp_fail_command` - Handle transient failures
  - `sp_update_batch_counters` - Central batch counter helper
  - `sp_start_batch` - Transition batch PENDING -> IN_PROGRESS
  - `sp_tsq_complete`, `sp_tsq_cancel`, `sp_tsq_retry` - TSQ operations
- Add F010 feature documentation and story files (S046-S050)

## Changes

This is the first step in the F010 Database Schema Management feature. It creates the migration file but does not yet:
- Update Docker Compose to use Flyway (S048)
- Update Python code for schema-qualified names (S049)
- Clean up legacy migrations (S050)

Those changes will follow in subsequent PRs.

## Test plan

- [x] Migration file syntax is valid SQL
- [ ] Migration can be applied to fresh database (will test with S048)

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)