### PR TITLE
S049: Update Python code to use schema-qualified table names

### DIFF
--- a/src/commandbus/ops/troubleshooting.py
+++ b/src/commandbus/ops/troubleshooting.py
@@ -92,7 +92,7 @@ class TroubleshootingQueue:
                 a.message,
                 c.created_at,
                 c.updated_at
-            FROM command_bus_command c
+            FROM commandbus.command c
             LEFT JOIN {archive_table} a ON a.message->>'command_id' = c.command_id::text
             WHERE c.domain = %s
               AND c.status = %s
@@ -161,7 +161,7 @@ class TroubleshootingQueue:
         """
         query = """
             SELECT COUNT(*)
-            FROM command_bus_command
+            FROM commandbus.command
             WHERE domain = %s
               AND status = %s
         """
@@ -247,7 +247,7 @@ class TroubleshootingQueue:
                 # Update command metadata: status=PENDING, attempts=0, msg_id=new
                 await conn.execute(
                     """
-                    UPDATE command_bus_command
+                    UPDATE commandbus.command
                     SET status = %s, attempts = 0, msg_id = %s,
                         last_error_type = NULL, last_error_code = NULL,
                         last_error_msg = NULL, updated_at = NOW()
@@ -323,7 +323,7 @@ class TroubleshootingQueue:
                 # Update command status to CANCELED
                 await conn.execute(
                     """
-                    UPDATE command_bus_command
+                    UPDATE commandbus.command
                     SET status = %s, updated_at = NOW()
                     WHERE domain = %s AND command_id = %s
                     """,
@@ -417,7 +417,7 @@ class TroubleshootingQueue:
                 # Update command status to COMPLETED
                 await conn.execute(
                     """
-                    UPDATE command_bus_command
+                    UPDATE commandbus.command
                     SET status = %s, updated_at = NOW()
                     WHERE domain = %s AND command_id = %s
                     """,

--- a/src/commandbus/repositories/audit.py
+++ b/src/commandbus/repositories/audit.py
@@ -94,7 +94,7 @@ class PostgresAuditLogger:
         details_json = json.dumps(details) if details else None
         await conn.execute(
             """
-            INSERT INTO command_bus_audit (domain, command_id, event_type, details_json)
+            INSERT INTO commandbus.audit (domain, command_id, event_type, details_json)
             VALUES (%s, %s, %s, %s::jsonb)
             """,
             (domain, command_id, event_type.value, details_json),
@@ -148,7 +148,7 @@ class PostgresAuditLogger:
                     await cur.execute(
                         """
                         SELECT audit_id, domain, command_id, event_type, ts, details_json
-                        FROM command_bus_audit
+                        FROM commandbus.audit
                         WHERE command_id = %s AND domain = %s
                         ORDER BY ts ASC
                         """,
@@ -158,7 +158,7 @@ class PostgresAuditLogger:
                     await cur.execute(
                         """
                         SELECT audit_id, domain, command_id, event_type, ts, details_json
-                        FROM command_bus_audit
+                        FROM commandbus.audit
                         WHERE command_id = %s
                         ORDER BY ts ASC
                         """,

--- a/src/commandbus/repositories/batch.py
+++ b/src/commandbus/repositories/batch.py
@@ -54,7 +54,7 @@ class PostgresBatchRepository:
         custom_data_json = json.dumps(metadata.custom_data) if metadata.custom_data else None
         await conn.execute(
             """
-            INSERT INTO command_bus_batch (
+            INSERT INTO commandbus.batch (
                 domain, batch_id, name, custom_data, status,
                 total_count, completed_count,
                 canceled_count, in_troubleshooting_count,
@@ -114,7 +114,7 @@ class PostgresBatchRepository:
                        total_count, completed_count,
                        canceled_count, in_troubleshooting_count,
                        created_at, started_at, completed_at
-                FROM command_bus_batch
+                FROM commandbus.batch
                 WHERE domain = %s AND batch_id = %s
                 """,
                 (domain, batch_id),
@@ -159,7 +159,7 @@ class PostgresBatchRepository:
             await cur.execute(
                 """
                 SELECT EXISTS(
-                    SELECT 1 FROM command_bus_batch
+                    SELECT 1 FROM commandbus.batch
                     WHERE domain = %s AND batch_id = %s
                 )
                 """,
@@ -222,7 +222,7 @@ class PostgresBatchRepository:
                        total_count, completed_count,
                        canceled_count, in_troubleshooting_count,
                        created_at, started_at, completed_at
-                FROM command_bus_batch
+                FROM commandbus.batch
                 WHERE {where_clause}
                 ORDER BY created_at DESC
                 LIMIT %s OFFSET %s
@@ -295,7 +295,7 @@ class PostgresBatchRepository:
         """TSQ complete using stored procedure."""
         async with conn.cursor() as cur:
             await cur.execute(
-                "SELECT sp_tsq_complete(%s, %s)",
+                "SELECT commandbus.sp_tsq_complete(%s, %s)",
                 (domain, batch_id),
             )
             row = await cur.fetchone()
@@ -337,7 +337,7 @@ class PostgresBatchRepository:
         """TSQ cancel using stored procedure."""
         async with conn.cursor() as cur:
             await cur.execute(
-                "SELECT sp_tsq_cancel(%s, %s)",
+                "SELECT commandbus.sp_tsq_cancel(%s, %s)",
                 (domain, batch_id),
             )
             row = await cur.fetchone()
@@ -376,7 +376,7 @@ class PostgresBatchRepository:
         """TSQ retry using stored procedure."""
         async with conn.cursor() as cur:
             await cur.execute(
-                "SELECT sp_tsq_retry(%s, %s)",
+                "SELECT commandbus.sp_tsq_retry(%s, %s)",
                 (domain, batch_id),
             )
             logger.debug(f"Batch {domain}.{batch_id} TSQ retry processed")

--- a/src/commandbus/repositories/command.py
+++ b/src/commandbus/repositories/command.py
@@ -111,7 +111,7 @@ class PostgresCommandRepository:
         """Save metadata using an existing connection."""
         await conn.execute(
             """
-            INSERT INTO command_bus_command (
+            INSERT INTO commandbus.command (
                 domain, queue_name, msg_id, command_id, command_type,
                 status, attempts, max_attempts, correlation_id, reply_queue,
                 created_at, updated_at, batch_id
@@ -156,7 +156,7 @@ class PostgresCommandRepository:
         async with conn.cursor() as cur:
             await cur.executemany(
                 """
-                INSERT INTO command_bus_command (
+                INSERT INTO commandbus.command (
                     domain, queue_name, msg_id, command_id, command_type,
                     status, attempts, max_attempts, correlation_id, reply_queue,
                     created_at, updated_at, batch_id
@@ -205,7 +205,7 @@ class PostgresCommandRepository:
         async with conn.cursor() as cur:
             await cur.execute(
                 """
-                SELECT command_id FROM command_bus_command
+                SELECT command_id FROM commandbus.command
                 WHERE domain = %s AND command_id = ANY(%s)
                 """,
                 (domain, command_ids),
@@ -249,7 +249,7 @@ class PostgresCommandRepository:
                        max_attempts, msg_id, correlation_id, reply_queue,
                        last_error_type, last_error_code, last_error_msg,
                        created_at, updated_at, batch_id
-                FROM command_bus_command
+                FROM commandbus.command
                 WHERE domain = %s AND command_id = %s
                 """,
                 (domain, command_id),
@@ -308,7 +308,7 @@ class PostgresCommandRepository:
         """Update status using an existing connection."""
         await conn.execute(
             """
-            UPDATE command_bus_command
+            UPDATE commandbus.command
             SET status = %s, updated_at = NOW()
             WHERE domain = %s AND command_id = %s
             """,
@@ -347,7 +347,7 @@ class PostgresCommandRepository:
         """Update msg_id using an existing connection."""
         await conn.execute(
             """
-            UPDATE command_bus_command
+            UPDATE commandbus.command
             SET msg_id = %s, updated_at = NOW()
             WHERE domain = %s AND command_id = %s
             """,
@@ -386,7 +386,7 @@ class PostgresCommandRepository:
         async with conn.cursor() as cur:
             await cur.execute(
                 """
-                UPDATE command_bus_command
+                UPDATE commandbus.command
                 SET attempts = attempts + 1, updated_at = NOW()
                 WHERE domain = %s AND command_id = %s
                 RETURNING attempts
@@ -443,7 +443,7 @@ class PostgresCommandRepository:
         async with conn.cursor() as cur:
             await cur.execute(
                 """
-                UPDATE command_bus_command
+                UPDATE commandbus.command
                 SET attempts = attempts + 1,
                     status = %s,
                     updated_at = NOW()
@@ -520,7 +520,7 @@ class PostgresCommandRepository:
         """Update error info using an existing connection."""
         await conn.execute(
             """
-            UPDATE command_bus_command
+            UPDATE commandbus.command
             SET last_error_type = %s, last_error_code = %s, last_error_msg = %s,
                 updated_at = NOW()
             WHERE domain = %s AND command_id = %s
@@ -576,7 +576,7 @@ class PostgresCommandRepository:
         """Finish command using an existing connection."""
         await conn.execute(
             """
-            UPDATE command_bus_command
+            UPDATE commandbus.command
             SET status = %s,
                 last_error_type = COALESCE(%s, last_error_type),
                 last_error_code = COALESCE(%s, last_error_code),
@@ -621,7 +621,7 @@ class PostgresCommandRepository:
             await cur.execute(
                 """
                 SELECT EXISTS(
-                    SELECT 1 FROM command_bus_command
+                    SELECT 1 FROM commandbus.command
                     WHERE domain = %s AND command_id = %s
                 )
                 """,
@@ -681,7 +681,7 @@ class PostgresCommandRepository:
                        max_attempts, msg_id, correlation_id, reply_queue,
                        last_error_type, last_error_code, last_error_msg,
                        created_at, updated_at, batch_id
-                FROM command_bus_command
+                FROM commandbus.command
                 WHERE {where_clause}
                 ORDER BY created_at ASC
                 LIMIT %s OFFSET %s
@@ -782,7 +782,7 @@ class PostgresCommandRepository:
         """Call sp_receive_command stored procedure."""
         async with conn.cursor() as cur:
             await cur.execute(
-                "SELECT * FROM sp_receive_command(%s, %s, %s, %s, %s)",
+                "SELECT * FROM commandbus.sp_receive_command(%s, %s, %s, %s, %s)",
                 (domain, command_id, "IN_PROGRESS", msg_id, max_attempts),
             )
             row = await cur.fetchone()
@@ -888,7 +888,7 @@ class PostgresCommandRepository:
         """Call sp_finish_command stored procedure."""
         async with conn.cursor() as cur:
             await cur.execute(
-                "SELECT sp_finish_command(%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s)",
+                "SELECT commandbus.sp_finish_command(%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s)",
                 (
                     domain,
                     command_id,
@@ -976,7 +976,7 @@ class PostgresCommandRepository:
         """Call sp_fail_command stored procedure."""
         async with conn.cursor() as cur:
             await cur.execute(
-                "SELECT sp_fail_command(%s, %s, %s, %s, %s, %s, %s, %s)",
+                "SELECT commandbus.sp_fail_command(%s, %s, %s, %s, %s, %s, %s, %s)",
                 (
                     domain,
                     command_id,
@@ -1036,7 +1036,7 @@ class PostgresCommandRepository:
                        max_attempts, msg_id, correlation_id, reply_queue,
                        last_error_type, last_error_code, last_error_msg,
                        created_at, updated_at, batch_id
-                FROM command_bus_command
+                FROM commandbus.command
                 WHERE {where_clause}
                 ORDER BY created_at DESC
                 LIMIT %s OFFSET %s

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -96,9 +96,9 @@ async def cleanup_payments_domain(pool: AsyncConnectionPool) -> AsyncGenerator[N
         await conn.execute("SELECT pgmq.create('reports__replies')")
 
         # Clean up before test (commands must be deleted before batches due to FK)
-        await conn.execute("DELETE FROM command_bus_audit WHERE domain = 'payments'")
-        await conn.execute("DELETE FROM command_bus_command WHERE domain = 'payments'")
-        await conn.execute("DELETE FROM command_bus_batch WHERE domain = 'payments'")
+        await conn.execute("DELETE FROM commandbus.audit WHERE domain = 'payments'")
+        await conn.execute("DELETE FROM commandbus.command WHERE domain = 'payments'")
+        await conn.execute("DELETE FROM commandbus.batch WHERE domain = 'payments'")
         await conn.execute("DELETE FROM pgmq.q_payments__commands")
         await conn.execute("DELETE FROM pgmq.q_payments__replies")
         await conn.execute("DELETE FROM pgmq.q_reports__replies")
@@ -107,9 +107,9 @@ async def cleanup_payments_domain(pool: AsyncConnectionPool) -> AsyncGenerator[N
 
     # Clean up after test
     async with pool.connection() as conn:
-        await conn.execute("DELETE FROM command_bus_audit WHERE domain = 'payments'")
-        await conn.execute("DELETE FROM command_bus_command WHERE domain = 'payments'")
-        await conn.execute("DELETE FROM command_bus_batch WHERE domain = 'payments'")
+        await conn.execute("DELETE FROM commandbus.audit WHERE domain = 'payments'")
+        await conn.execute("DELETE FROM commandbus.command WHERE domain = 'payments'")
+        await conn.execute("DELETE FROM commandbus.batch WHERE domain = 'payments'")
         await conn.execute("DELETE FROM pgmq.q_payments__commands")
         await conn.execute("DELETE FROM pgmq.q_payments__replies")
         await conn.execute("DELETE FROM pgmq.q_reports__replies")

--- a/tests/integration/test_audit.py
+++ b/tests/integration/test_audit.py
@@ -56,14 +56,14 @@ async def tsq(pool: AsyncConnectionPool) -> TroubleshootingQueue:
 async def cleanup_db(pool: AsyncConnectionPool):
     """Clean up test data before and after each test."""
     async with pool.connection() as conn:
-        await conn.execute("DELETE FROM command_bus_audit")
-        await conn.execute("DELETE FROM command_bus_command")
+        await conn.execute("DELETE FROM commandbus.audit")
+        await conn.execute("DELETE FROM commandbus.command")
         await conn.execute("DELETE FROM pgmq.q_payments__commands")
         await conn.execute("DELETE FROM pgmq.q_reports__replies")
     yield
     async with pool.connection() as conn:
-        await conn.execute("DELETE FROM command_bus_audit")
-        await conn.execute("DELETE FROM command_bus_command")
+        await conn.execute("DELETE FROM commandbus.audit")
+        await conn.execute("DELETE FROM commandbus.command")
         await conn.execute("DELETE FROM pgmq.q_payments__commands")
         await conn.execute("DELETE FROM pgmq.q_reports__replies")
 

--- a/tests/integration/test_correlation_id.py
+++ b/tests/integration/test_correlation_id.py
@@ -13,7 +13,8 @@ from commandbus.bus import CommandBus
 def database_url() -> str:
     """Get database URL from environment."""
     return os.environ.get(
-        "DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/commandbus"
+        "DATABASE_URL",
+        "postgresql://postgres:postgres@localhost:5432/commandbus",  # pragma: allowlist secret
     )
 
 
@@ -37,8 +38,8 @@ async def cleanup_db(pool: AsyncConnectionPool):
     """Clean up test data after each test."""
     yield
     async with pool.connection() as conn:
-        await conn.execute("DELETE FROM command_bus_audit")
-        await conn.execute("DELETE FROM command_bus_command")
+        await conn.execute("DELETE FROM commandbus.audit")
+        await conn.execute("DELETE FROM commandbus.command")
 
 
 @pytest.mark.integration
@@ -66,7 +67,7 @@ async def test_send_with_explicit_correlation_id(
     # Verify correlation_id in audit event
     async with pool.connection() as conn, conn.cursor() as cur:
         await cur.execute(
-            "SELECT details_json FROM command_bus_audit WHERE command_id = %s",
+            "SELECT details_json FROM commandbus.audit WHERE command_id = %s",
             (command_id,),
         )
         row = await cur.fetchone()
@@ -99,7 +100,7 @@ async def test_send_generates_correlation_id_when_not_provided(
     # Verify correlation_id in audit event matches metadata
     async with pool.connection() as conn, conn.cursor() as cur:
         await cur.execute(
-            "SELECT details_json FROM command_bus_audit WHERE command_id = %s",
+            "SELECT details_json FROM commandbus.audit WHERE command_id = %s",
             (command_id,),
         )
         row = await cur.fetchone()

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -42,14 +42,14 @@ async def command_bus(pool: AsyncConnectionPool) -> CommandBus:
 async def cleanup_db(pool: AsyncConnectionPool):
     """Clean up test data before and after each test."""
     async with pool.connection() as conn:
-        await conn.execute("DELETE FROM command_bus_audit")
-        await conn.execute("DELETE FROM command_bus_command")
+        await conn.execute("DELETE FROM commandbus.audit")
+        await conn.execute("DELETE FROM commandbus.command")
         await conn.execute("DELETE FROM pgmq.q_payments__commands")
         await conn.execute("DELETE FROM pgmq.q_reports__commands")
     yield
     async with pool.connection() as conn:
-        await conn.execute("DELETE FROM command_bus_audit")
-        await conn.execute("DELETE FROM command_bus_command")
+        await conn.execute("DELETE FROM commandbus.audit")
+        await conn.execute("DELETE FROM commandbus.command")
         await conn.execute("DELETE FROM pgmq.q_payments__commands")
         await conn.execute("DELETE FROM pgmq.q_reports__commands")
 

--- a/tests/integration/test_send_idempotency.py
+++ b/tests/integration/test_send_idempotency.py
@@ -15,7 +15,8 @@ from commandbus.models import CommandStatus
 def database_url() -> str:
     """Get database URL from environment."""
     return os.environ.get(
-        "DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/commandbus"
+        "DATABASE_URL",
+        "postgresql://postgres:postgres@localhost:5432/commandbus",  # pragma: allowlist secret
     )
 
 
@@ -39,8 +40,8 @@ async def cleanup_db(pool: AsyncConnectionPool):
     """Clean up test data after each test."""
     yield
     async with pool.connection() as conn:
-        await conn.execute("DELETE FROM command_bus_audit")
-        await conn.execute("DELETE FROM command_bus_command")
+        await conn.execute("DELETE FROM commandbus.audit")
+        await conn.execute("DELETE FROM commandbus.command")
 
 
 @pytest.mark.integration
@@ -150,7 +151,7 @@ async def test_no_duplicate_metadata_created(
     # Count rows
     async with pool.connection() as conn, conn.cursor() as cur:
         await cur.execute(
-            "SELECT COUNT(*) FROM command_bus_command WHERE command_id = %s",
+            "SELECT COUNT(*) FROM commandbus.command WHERE command_id = %s",
             (command_id,),
         )
         row = await cur.fetchone()
@@ -168,7 +169,7 @@ async def test_no_duplicate_metadata_created(
     # Count rows again - should be unchanged
     async with pool.connection() as conn, conn.cursor() as cur:
         await cur.execute(
-            "SELECT COUNT(*) FROM command_bus_command WHERE command_id = %s",
+            "SELECT COUNT(*) FROM commandbus.command WHERE command_id = %s",
             (command_id,),
         )
         row = await cur.fetchone()

--- a/tests/unit/test_troubleshooting.py
+++ b/tests/unit/test_troubleshooting.py
@@ -596,7 +596,7 @@ class TestTroubleshootingQueueOperatorRetry:
             query = call_args[0][0]
             params = call_args[0][1]
 
-            assert "UPDATE command_bus_command" in query
+            assert "UPDATE commandbus.command" in query
             assert "status = %s" in query
             assert "attempts = 0" in query
             assert CommandStatus.PENDING.value in params
@@ -842,7 +842,7 @@ class TestTroubleshootingQueueOperatorCancel:
             query = call_args[0][0]
             params = call_args[0][1]
 
-            assert "UPDATE command_bus_command" in query
+            assert "UPDATE commandbus.command" in query
             assert "status = %s" in query
             assert CommandStatus.CANCELED.value in params
 
@@ -1177,7 +1177,7 @@ class TestTroubleshootingQueueOperatorComplete:
             query = call_args[0][0]
             params = call_args[0][1]
 
-            assert "UPDATE command_bus_command" in query
+            assert "UPDATE commandbus.command" in query
             assert "status = %s" in query
             assert CommandStatus.COMPLETED.value in params
 


### PR DESCRIPTION
## Summary
- Updates all Python repository files to use schema-qualified table names (`commandbus.command`, `commandbus.batch`, `commandbus.audit`)
- Updates all stored procedure calls to use schema-qualified names (`commandbus.sp_*`)
- Updates all integration and unit tests to use the new table names
- Adds `pragma: allowlist secret` comments to test files for secret detection

## Changes

### Repositories
- `command_bus_command` → `commandbus.command`
- `command_bus_batch` → `commandbus.batch`
- `command_bus_audit` → `commandbus.audit`

### Stored Procedures
- `sp_receive_command` → `commandbus.sp_receive_command`
- `sp_finish_command` → `commandbus.sp_finish_command`
- `sp_fail_command` → `commandbus.sp_fail_command`
- `sp_tsq_complete` → `commandbus.sp_tsq_complete`
- `sp_tsq_cancel` → `commandbus.sp_tsq_cancel`
- `sp_tsq_retry` → `commandbus.sp_tsq_retry`

## Test plan
- [x] Unit tests pass (284 tests)
- [x] Integration tests pass (87 tests)
- [x] Code aligned with Flyway-managed database schema

Resolves #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)