### PR TITLE
feat: configure package metadata for PyPI publishing

### DIFF
--- a/docs/features/F012-pypi-publishing.md
+++ b/docs/features/F012-pypi-publishing.md
@@ -1,0 +1,204 @@
+# F012: PyPI Publishing
+
+## Overview
+
+Automate publishing the `commandbus` library to PyPI using GitHub Actions with trusted publishing (OIDC), eliminating the need for long-lived API tokens.
+
+## Goals
+
+1. Publish package to PyPI on tagged releases
+2. Use trusted publishing (OIDC) for secure, tokenless authentication
+3. Automate version management from git tags
+4. Include proper package metadata for PyPI listing
+
+## Implementation
+
+### 1. Package Configuration
+
+Update `pyproject.toml` with PyPI metadata:
+
+```toml
+[project]
+name = "commandbus"
+dynamic = ["version"]
+description = "Command Bus abstraction over PostgreSQL + PGMQ"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.11"
+authors = [
+    { name = "Your Name", email = "your@email.com" }
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Framework :: AsyncIO",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Database",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["commandbus", "cqrs", "pgmq", "postgresql", "async"]
+
+[project.urls]
+Homepage = "https://github.com/FreeSideNomad/rcmd"
+Repository = "https://github.com/FreeSideNomad/rcmd"
+Documentation = "https://github.com/FreeSideNomad/rcmd#readme"
+
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/commandbus"]
+```
+
+### 2. GitHub Actions Workflow
+
+Create `.github/workflows/publish.yml`:
+
+```yaml
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for hatch-vcs
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # Required for trusted publishing
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+```
+
+### 3. PyPI Trusted Publishing Setup
+
+1. Go to https://pypi.org/manage/account/publishing/
+2. Add a new pending publisher:
+   - PyPI Project Name: `commandbus`
+   - Owner: `FreeSideNomad`
+   - Repository: `rcmd`
+   - Workflow name: `publish.yml`
+   - Environment name: `pypi`
+
+3. Create GitHub environment:
+   - Go to repository Settings > Environments
+   - Create environment named `pypi`
+   - Optionally add protection rules (require approval)
+
+### 4. Release Process
+
+```bash
+# Create and push a version tag
+git tag v0.1.0
+git push origin v0.1.0
+
+# GitHub Actions will automatically:
+# 1. Build the package
+# 2. Publish to PyPI using trusted publishing
+```
+
+## User Stories
+
+### S057: Package Metadata Configuration
+Configure pyproject.toml with proper metadata for PyPI listing including description, classifiers, and URLs.
+
+**Acceptance Criteria:**
+- Package name is `commandbus`
+- Version is derived from git tags via hatch-vcs
+- All required metadata fields populated
+- Classifiers reflect project status
+
+### S058: GitHub Actions Publish Workflow
+Create workflow that builds and publishes on version tags.
+
+**Acceptance Criteria:**
+- Workflow triggers on `v*` tags only
+- Uses trusted publishing (OIDC)
+- Builds wheel and source distribution
+- Publishes to PyPI
+
+### S059: Trusted Publishing Setup
+Configure PyPI trusted publishing for tokenless authentication.
+
+**Acceptance Criteria:**
+- Pending publisher configured on PyPI
+- GitHub environment `pypi` created
+- No API tokens required
+
+## Security Notes
+
+- **Never commit PyPI tokens** to the repository
+- Trusted publishing (OIDC) is the recommended approach
+- If tokens are accidentally exposed, revoke immediately at https://pypi.org/manage/account/token/
+- GitHub environment protection can require manual approval before publishing
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `pyproject.toml` | Add PyPI metadata and hatch-vcs |
+| `.github/workflows/publish.yml` | New publish workflow |
+| `README.md` | Add PyPI badge and install instructions |
+
+## Testing
+
+Before first publish:
+```bash
+# Build locally to verify
+pip install build
+python -m build
+
+# Check the built package
+pip install dist/commandbus-*.whl
+python -c "import commandbus; print(commandbus.__version__)"
+```
+
+## References
+
+- [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/)
+- [Hatch VCS](https://github.com/ofek/hatch-vcs)
+- [GitHub Actions PyPI Publish](https://github.com/pypa/gh-action-pypi-publish)

--- a/docs/features/stories/F012-pypi-publishing.md
+++ b/docs/features/stories/F012-pypi-publishing.md
@@ -1,0 +1,292 @@
+# F012: PyPI Publishing - User Stories
+
+## S057: Package Metadata Configuration
+
+**As a** library maintainer
+**I want** proper PyPI metadata in pyproject.toml
+**So that** users can discover and understand the package on PyPI
+
+### Description
+
+Configure `pyproject.toml` with all required and recommended metadata fields for a professional PyPI listing. Use `hatch-vcs` for automatic version derivation from git tags.
+
+### Acceptance Criteria
+
+- [ ] Package name is `commandbus`
+- [ ] Version is dynamically derived from git tags using hatch-vcs
+- [ ] Description clearly states the library purpose
+- [ ] README.md is used as the long description
+- [ ] License is specified (MIT)
+- [ ] Python version requirement is >=3.11
+- [ ] Author information is populated
+- [ ] Classifiers reflect project status and compatibility
+- [ ] Keywords aid discoverability
+- [ ] Project URLs include homepage, repository, and documentation
+- [ ] Build system uses hatchling with hatch-vcs
+
+### Technical Details
+
+Update `pyproject.toml`:
+
+```toml
+[project]
+name = "commandbus"
+dynamic = ["version"]
+description = "Command Bus abstraction over PostgreSQL + PGMQ for reliable async command processing"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.11"
+authors = [
+    { name = "FreeSideNomad" }
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Framework :: AsyncIO",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Database",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+keywords = ["commandbus", "cqrs", "pgmq", "postgresql", "async", "message-queue"]
+
+[project.urls]
+Homepage = "https://github.com/FreeSideNomad/rcmd"
+Repository = "https://github.com/FreeSideNomad/rcmd"
+Documentation = "https://github.com/FreeSideNomad/rcmd#readme"
+Issues = "https://github.com/FreeSideNomad/rcmd/issues"
+
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src/commandbus",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/commandbus"]
+```
+
+### Dependencies
+
+- Add `hatchling` and `hatch-vcs` as build dependencies
+
+### Testing
+
+```bash
+# Verify build works locally
+pip install build
+python -m build
+
+# Check package contents
+tar -tzf dist/commandbus-*.tar.gz
+unzip -l dist/commandbus-*.whl
+
+# Test installation
+pip install dist/commandbus-*.whl
+python -c "import commandbus; print(commandbus.__version__)"
+```
+
+---
+
+## S058: GitHub Actions Publish Workflow
+
+**As a** library maintainer
+**I want** an automated publish workflow
+**So that** packages are published to PyPI when I create version tags
+
+### Description
+
+Create a GitHub Actions workflow that triggers on version tags (`v*`), builds the package distribution, and publishes to PyPI using trusted publishing (OIDC).
+
+### Acceptance Criteria
+
+- [ ] Workflow triggers only on tags matching `v*` pattern
+- [ ] Workflow builds both wheel and source distribution
+- [ ] Built artifacts are uploaded for inspection
+- [ ] Publishing uses trusted publishing (OIDC) - no API tokens
+- [ ] Workflow requires `pypi` environment for publishing step
+- [ ] Publishing step has `id-token: write` permission
+- [ ] Workflow uses latest stable action versions
+
+### Technical Details
+
+Create `.github/workflows/publish.yml`:
+
+```yaml
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for hatch-vcs version detection
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: List built artifacts
+        run: ls -la dist/
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # OIDC token for trusted publishing
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+```
+
+### Testing
+
+1. Create a test tag locally (don't push):
+   ```bash
+   git tag v0.0.1-test
+   ```
+
+2. Verify workflow syntax:
+   ```bash
+   gh workflow view publish.yml
+   ```
+
+3. First real publish:
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   gh run watch
+   ```
+
+---
+
+## S059: PyPI Trusted Publishing Setup
+
+**As a** library maintainer
+**I want** tokenless PyPI authentication
+**So that** publishing is secure without managing API tokens
+
+### Description
+
+Configure PyPI trusted publishing (OIDC) to allow GitHub Actions to publish without storing API tokens. This requires configuration on both PyPI and GitHub.
+
+### Acceptance Criteria
+
+- [ ] Pending publisher registered on PyPI for `commandbus` package
+- [ ] Publisher configured with correct GitHub repository details
+- [ ] GitHub environment `pypi` created in repository settings
+- [ ] Environment protection rules configured (optional but recommended)
+- [ ] No API tokens stored in repository secrets
+- [ ] Documentation updated with publishing instructions
+
+### Technical Details
+
+#### PyPI Configuration
+
+1. Go to https://pypi.org/manage/account/publishing/
+2. Add pending publisher with:
+   - **PyPI Project Name:** `commandbus`
+   - **Owner:** `FreeSideNomad`
+   - **Repository:** `rcmd`
+   - **Workflow name:** `publish.yml`
+   - **Environment name:** `pypi`
+
+#### GitHub Configuration
+
+1. Go to repository Settings > Environments
+2. Create new environment: `pypi`
+3. Configure protection rules (recommended):
+   - Required reviewers: Add maintainers
+   - Wait timer: 0 minutes (optional delay)
+   - Deployment branches: Only `main` or tags
+
+#### README Updates
+
+Add PyPI badge and installation instructions:
+
+```markdown
+[![PyPI version](https://badge.fury.io/py/commandbus.svg)](https://badge.fury.io/py/commandbus)
+[![Python Versions](https://img.shields.io/pypi/pyversions/commandbus.svg)](https://pypi.org/project/commandbus/)
+
+## Installation
+
+```bash
+pip install commandbus
+```
+```
+
+### Security Notes
+
+- Trusted publishing uses GitHub's OIDC provider
+- No long-lived secrets to rotate or leak
+- Publishing is tied to specific workflow and environment
+- Environment protection adds manual approval gate
+
+### Release Checklist
+
+When creating a new release:
+
+1. Update CHANGELOG.md (if exists)
+2. Ensure all tests pass on main
+3. Create annotated tag:
+   ```bash
+   git tag -a v0.1.0 -m "Release v0.1.0"
+   git push origin v0.1.0
+   ```
+4. Monitor GitHub Actions workflow
+5. Verify package on PyPI
+
+---
+
+## Dependencies Between Stories
+
+```
+S057 (Package Metadata)
+    ↓
+S058 (Publish Workflow) ← S059 (Trusted Publishing)
+```
+
+- S057 must be completed first (workflow needs proper pyproject.toml)
+- S058 and S059 can be done in parallel but both needed for successful publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,15 @@
 [project]
 name = "commandbus"
-version = "0.1.0"
-description = "Command Bus abstraction over PostgreSQL + PGMQ"
+dynamic = ["version"]
+description = "Command Bus abstraction over PostgreSQL + PGMQ for reliable async command processing"
 readme = "README.md"
-license = "Apache-2.0"
+license = "MIT"
 requires-python = ">=3.11"
 authors = [
-    { name = "Your Name", email = "you@example.com" }
-]
-maintainers = [
-    { name = "Your Name", email = "you@example.com" }
+    { name = "FreeSideNomad" }
 ]
 keywords = [
+    "commandbus",
     "command-bus",
     "cqrs",
     "postgresql",
@@ -20,14 +18,16 @@ keywords = [
     "async",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
+    "Framework :: AsyncIO",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Topic :: Database",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
@@ -61,15 +61,25 @@ e2e = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/your-org/commandbus"
-Documentation = "https://github.com/your-org/commandbus#readme"
-Repository = "https://github.com/your-org/commandbus"
-Issues = "https://github.com/your-org/commandbus/issues"
-Changelog = "https://github.com/your-org/commandbus/releases"
+Homepage = "https://github.com/FreeSideNomad/rcmd"
+Documentation = "https://github.com/FreeSideNomad/rcmd#readme"
+Repository = "https://github.com/FreeSideNomad/rcmd"
+Issues = "https://github.com/FreeSideNomad/rcmd/issues"
+Changelog = "https://github.com/FreeSideNomad/rcmd/releases"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src/commandbus",
+    "/README.md",
+    "/LICENSE",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/commandbus"]

--- a/src/commandbus/__init__.py
+++ b/src/commandbus/__init__.py
@@ -84,6 +84,7 @@ __all__ = [
     "TroubleshootingItem",
     "TroubleshootingQueue",
     "Worker",
+    "__version__",
     "check_and_invoke_batch_callback",
     "clear_all_callbacks",
     "get_batch_callback",
@@ -92,4 +93,10 @@ __all__ = [
     "remove_batch_callback",
 ]
 
-__version__ = "0.1.0"
+# Version is set dynamically by hatch-vcs from git tags
+try:
+    from importlib.metadata import version
+
+    __version__ = version("commandbus")
+except Exception:
+    __version__ = "0.0.0+unknown"

--- a/uv.lock
+++ b/uv.lock
@@ -147,7 +147,6 @@ wheels = [
 
 [[package]]
 name = "commandbus"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },
@@ -197,7 +196,7 @@ requires-dist = [
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'test'", specifier = ">=4.0.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'e2e'", specifier = ">=0.40.0" },
 ]
-provides-extras = ["dev", "test", "e2e"]
+provides-extras = ["dev", "e2e", "test"]
 
 [[package]]
 name = "coverage"


### PR DESCRIPTION
## Summary
- Configure dynamic version from git tags via hatch-vcs
- Update package metadata (description, license MIT, classifiers, URLs)
- Add `__version__` using `importlib.metadata`
- Add build-system with hatchling and hatch-vcs
- Add documentation for F012 PyPI Publishing feature

## Test plan
- [x] Local build succeeds with `python -m build`
- [x] Version is correctly derived from git tags
- [x] Package installs and `import commandbus; print(commandbus.__version__)` works
- [x] Unit tests pass with 80%+ coverage

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)