### PR TITLE
feat: add GitHub Actions workflow for PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for hatch-vcs version detection
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: List built artifacts
+        run: ls -la dist/
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # OIDC token for trusted publishing
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Add `.github/workflows/publish.yml` triggered on `v*` tags
- Build wheel and source distribution using `python -m build`
- Publish to PyPI using trusted publishing (OIDC) - no API tokens needed
- Requires `pypi` GitHub environment for publishing step

## Test plan
- [x] Workflow YAML is valid
- [ ] Workflow runs on tag push (will test with first release)
- [ ] Package published to PyPI (requires S059 trusted publishing setup)

## Note
This workflow requires S059 (Trusted Publishing Setup) to be configured on PyPI before the first publish will succeed.

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)