### PR TITLE
docs: add PyPI badges and trusted publishing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # rcmd - Reliable Commands
 
+[![PyPI version](https://badge.fury.io/py/commandbus.svg)](https://badge.fury.io/py/commandbus)
+[![Python Versions](https://img.shields.io/pypi/pyversions/commandbus.svg)](https://pypi.org/project/commandbus/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A Python library providing Command Bus abstraction over PostgreSQL + PGMQ.
+
+## Installation
+
+```bash
+pip install commandbus
+```
 
 ## Overview
 
@@ -303,4 +313,4 @@ The E2E UI provides:
 
 ## License
 
-Apache 2.0
+MIT


### PR DESCRIPTION
## Summary
- Add PyPI version and Python versions badges to README
- Add MIT license badge
- Add `pip install commandbus` installation instructions
- Update license reference to MIT

## Manual Setup Required

Before the first release, complete these manual steps:

### 1. PyPI Trusted Publishing Configuration
Go to https://pypi.org/manage/account/publishing/ and add a pending publisher:
- **PyPI Project Name:** `commandbus`
- **Owner:** `FreeSideNomad`
- **Repository:** `rcmd`
- **Workflow name:** `publish.yml`
- **Environment name:** `pypi`

### 2. GitHub Environment Configuration
Go to repository Settings > Environments and create:
- **Environment name:** `pypi`
- **Protection rules (optional):** Required reviewers, deployment branches

### 3. First Release
```bash
git tag -a v0.1.0 -m "Release v0.1.0"
git push origin v0.1.0
```

## Test plan
- [x] README renders correctly with badges
- [ ] PyPI trusted publishing configured (manual)
- [ ] GitHub environment created (manual)
- [ ] First release publishes successfully (after manual setup)

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)