### PR TITLE
fix: use correct PyPI package name 'reliable-cmd'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rcmd - Reliable Commands
 
-[![PyPI version](https://badge.fury.io/py/commandbus.svg)](https://badge.fury.io/py/commandbus)
-[![Python Versions](https://img.shields.io/pypi/pyversions/commandbus.svg)](https://pypi.org/project/commandbus/)
+[![PyPI version](https://badge.fury.io/py/reliable-cmd.svg)](https://badge.fury.io/py/reliable-cmd)
+[![Python Versions](https://img.shields.io/pypi/pyversions/reliable-cmd.svg)](https://pypi.org/project/reliable-cmd/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A Python library providing Command Bus abstraction over PostgreSQL + PGMQ.
@@ -9,7 +9,7 @@ A Python library providing Command Bus abstraction over PostgreSQL + PGMQ.
 ## Installation
 
 ```bash
-pip install commandbus
+pip install reliable-cmd
 ```
 
 ## Overview

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "commandbus"
+name = "reliable-cmd"
 dynamic = ["version"]
 description = "Command Bus abstraction over PostgreSQL + PGMQ for reliable async command processing"
 readme = "README.md"

--- a/src/commandbus/__init__.py
+++ b/src/commandbus/__init__.py
@@ -97,6 +97,6 @@ __all__ = [
 try:
     from importlib.metadata import version
 
-    __version__ = version("commandbus")
+    __version__ = version("reliable-cmd")
 except Exception:
     __version__ = "0.0.0+unknown"

--- a/uv.lock
+++ b/uv.lock
@@ -146,59 +146,6 @@ wheels = [
 ]
 
 [[package]]
-name = "commandbus"
-source = { editable = "." }
-dependencies = [
-    { name = "orjson" },
-    { name = "psycopg", extra = ["binary", "pool"] },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-]
-e2e = [
-    { name = "fastapi" },
-    { name = "jinja2" },
-    { name = "python-dotenv" },
-    { name = "python-multipart" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-test = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "testcontainers" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "fastapi", marker = "extra == 'e2e'", specifier = ">=0.128.0" },
-    { name = "jinja2", marker = "extra == 'e2e'", specifier = ">=3.1.6" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
-    { name = "orjson", specifier = ">=3.10.0" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
-    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0.0" },
-    { name = "python-dotenv", marker = "extra == 'e2e'", specifier = ">=1.0.1" },
-    { name = "python-multipart", marker = "extra == 'e2e'", specifier = ">=0.0.20" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
-    { name = "testcontainers", extras = ["postgres"], marker = "extra == 'test'", specifier = ">=4.0.0" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'e2e'", specifier = ">=0.40.0" },
-]
-provides-extras = ["dev", "e2e", "test"]
-
-[[package]]
 name = "coverage"
 version = "7.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1074,6 +1021,59 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
+
+[[package]]
+name = "reliable-cmd"
+source = { editable = "." }
+dependencies = [
+    { name = "orjson" },
+    { name = "psycopg", extra = ["binary", "pool"] },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+e2e = [
+    { name = "fastapi" },
+    { name = "jinja2" },
+    { name = "python-dotenv" },
+    { name = "python-multipart" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "testcontainers" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", marker = "extra == 'e2e'", specifier = ">=0.128.0" },
+    { name = "jinja2", marker = "extra == 'e2e'", specifier = ">=3.1.6" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
+    { name = "orjson", specifier = ">=3.10.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0.0" },
+    { name = "python-dotenv", marker = "extra == 'e2e'", specifier = ">=1.0.1" },
+    { name = "python-multipart", marker = "extra == 'e2e'", specifier = ">=0.0.20" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "testcontainers", extras = ["postgres"], marker = "extra == 'test'", specifier = ">=4.0.0" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'e2e'", specifier = ">=0.40.0" },
+]
+provides-extras = ["dev", "e2e", "test"]
 
 [[package]]
 name = "requests"


### PR DESCRIPTION
## Summary
Fix PyPI package name to match the registered project name `reliable-cmd`.

## Changes
- `pyproject.toml`: Change name from `commandbus` to `reliable-cmd`
- `README.md`: Update badges and install instructions
- `__init__.py`: Update version lookup to use `reliable-cmd`

## After merge
Delete old tag and create new one:
```bash
git tag -d v0.1.0
git push origin :refs/tags/v0.1.0
git checkout main && git pull
git tag -a v0.1.0 -m "Release v0.1.0"
git push origin v0.1.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)