### PR TITLE
fix: update README badges to use shields.io PyPI endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # rcmd - Reliable Commands
 
-[![PyPI version](https://badge.fury.io/py/reliable-cmd.svg)](https://badge.fury.io/py/reliable-cmd)
-[![Python Versions](https://img.shields.io/pypi/pyversions/reliable-cmd.svg)](https://pypi.org/project/reliable-cmd/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![PyPI version](https://img.shields.io/pypi/v/reliable-cmd)](https://pypi.org/project/reliable-cmd/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/reliable-cmd)](https://pypi.org/project/reliable-cmd/)
+[![License: MIT](https://img.shields.io/pypi/l/reliable-cmd)](https://opensource.org/licenses/MIT)
 
 A Python library providing Command Bus abstraction over PostgreSQL + PGMQ.
 


### PR DESCRIPTION
## Summary
Update badges to use shields.io `/pypi/` endpoints which pull directly from PyPI API.

**Before:** badge.fury.io (shows "not found")
**After:** shields.io/pypi (shows correct version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)