### PR TITLE
chore: remove S028 transaction participation feature (ctx.conn)

### DIFF
--- a/src/commandbus/worker.py
+++ b/src/commandbus/worker.py
@@ -25,7 +25,6 @@ from commandbus.repositories.batch import PostgresBatchRepository
 from commandbus.repositories.command import PostgresCommandRepository
 
 if TYPE_CHECKING:
-    from psycopg import AsyncConnection
     from psycopg_pool import AsyncConnectionPool
 
     from commandbus.handler import HandlerRegistry
@@ -681,12 +680,15 @@ class Worker:
         received: ReceivedCommand,
         semaphore: asyncio.Semaphore,
     ) -> None:
-        """Process a single command with transaction wrapping.
+        """Process a single command with semaphore control.
 
-        The handler and command completion are wrapped in a single transaction.
-        If the handler succeeds, both the handler's DB operations (if using
-        ctx.conn) and the command completion commit together. If the handler
-        raises an exception, the transaction is rolled back.
+        The handler runs without a transaction wrapper to allow handlers with
+        long-running operations (sleeps, external API calls) to not hold
+        database connections open. Command completion happens in a separate
+        transaction via self.complete().
+
+        Handlers that need transactional guarantees should manage their own
+        database transactions using their injected connection pool.
 
         Args:
             received: The received command to process
@@ -696,94 +698,26 @@ class Worker:
 
         async with semaphore:
             try:
-                is_batch_complete = False
-                async with self._pool.connection() as conn, conn.transaction():
-                    # Create context with connection for transaction participation
-                    context = HandlerContext(
-                        command=received.command,
-                        attempt=received.context.attempt,
-                        max_attempts=received.context.max_attempts,
-                        msg_id=received.msg_id,
-                        visibility_extender=received.context.visibility_extender,
-                        conn=conn,
-                    )
+                context = HandlerContext(
+                    command=received.command,
+                    attempt=received.context.attempt,
+                    max_attempts=received.context.max_attempts,
+                    msg_id=received.msg_id,
+                    visibility_extender=received.context.visibility_extender,
+                )
 
-                    # Handler executes within transaction
-                    result = await self._registry.dispatch(received.command, context)
+                result = await self._registry.dispatch(received.command, context)
 
-                    # Complete within same transaction
-                    is_batch_complete = await self._complete_in_txn(received, result, conn)
-
-                # Invoke batch completion callback (S043) - outside transaction
-                if is_batch_complete and received.metadata.batch_id is not None:
-                    await invoke_batch_callback(
-                        received.command.domain, received.metadata.batch_id, self._batch_repo
-                    )
+                # Complete in separate transaction
+                await self.complete(received, result=result)
 
             except TransientCommandError as e:
-                # Transaction rolled back, handle outside
+                # Explicit transient error - apply backoff and retry
                 await self.fail(received, e, is_transient=True)
             except PermanentCommandError as e:
-                # Transaction rolled back, move to troubleshooting queue
+                # Permanent error - move to troubleshooting queue
                 await self.fail_permanent(received, e)
             except Exception as e:
-                # Transaction rolled back, treat as transient
+                # Unknown exception treated as transient
                 logger.exception(f"Error processing command {received.command.command_id}")
                 await self.fail(received, e, is_transient=True)
-
-    async def _complete_in_txn(
-        self,
-        received: ReceivedCommand,
-        result: Any,
-        conn: AsyncConnection[Any],
-    ) -> bool:
-        """Complete a command within an existing transaction.
-
-        This is called from _process_command after the handler has executed
-        successfully. It performs the same operations as complete() but uses
-        the provided connection instead of opening a new one.
-
-        Args:
-            received: The received command to complete
-            result: Result data from the handler
-            conn: The connection within the transaction
-
-        Returns:
-            True if batch is now complete (for callback triggering)
-        """
-        command = received.command
-        command_id = command.command_id
-        domain = command.domain
-
-        # Delete message from queue
-        await self._pgmq.delete(self._queue_name, received.msg_id, conn)
-
-        # Use stored procedure: update status + insert audit + batch counter in ONE DB CALL
-        # Returns is_batch_complete for callback triggering
-        is_batch_complete = await self._command_repo.sp_finish_command(
-            domain,
-            command_id,
-            CommandStatus.COMPLETED,
-            event_type="COMPLETED",
-            details={
-                "msg_id": received.msg_id,
-                "reply_to": command.reply_to,
-                "has_result": result is not None,
-            },
-            batch_id=received.metadata.batch_id,
-            conn=conn,
-        )
-
-        # Send reply if reply_to is configured
-        if command.reply_to:
-            reply_message = {
-                "command_id": str(command_id),
-                "correlation_id": str(command.correlation_id) if command.correlation_id else None,
-                "outcome": ReplyOutcome.SUCCESS.value,
-                "result": result,
-            }
-            await self._pgmq.send(command.reply_to, reply_message, conn=conn)
-
-        logger.info(f"Completed command {domain}.{command.command_type} (command_id={command_id})")
-
-        return is_batch_complete

--- a/tests/e2e/app/models.py
+++ b/tests/e2e/app/models.py
@@ -117,25 +117,29 @@ class TestCommandRepository:
         async with self.pool.connection() as conn, conn.cursor() as cur:
             await cur.execute(
                 """
-                    UPDATE e2e.test_command
-                    SET attempts = attempts + 1
-                    WHERE command_id = %s
-                    RETURNING attempts
-                    """,
+                UPDATE e2e.test_command
+                SET attempts = attempts + 1
+                WHERE command_id = %s
+                RETURNING attempts
+                """,
                 (command_id,),
             )
             row = await cur.fetchone()
             return row[0] if row else 0
 
-    async def mark_processed(self, command_id: UUID, result: dict[str, Any] | None = None) -> None:
+    async def mark_processed(
+        self,
+        command_id: UUID,
+        result: dict[str, Any] | None = None,
+    ) -> None:
         """Mark command as processed."""
         async with self.pool.connection() as conn, conn.cursor() as cur:
             await cur.execute(
                 """
-                    UPDATE e2e.test_command
-                    SET processed_at = NOW(), result = %s
-                    WHERE command_id = %s
-                    """,
+                UPDATE e2e.test_command
+                SET processed_at = NOW(), result = %s
+                WHERE command_id = %s
+                """,
                 (Json(result) if result else None, command_id),
             )
 


### PR DESCRIPTION
## Summary

- Remove `conn` field from `HandlerContext` - handlers now manage their own transactions
- Remove `_complete_in_txn` method from worker - completion uses separate transaction
- Update README to document new handler transaction pattern
- Simplify E2E test handler and repository

## Root Cause (S028 Issue)

The S028 feature wrapped **entire handler execution** in a transaction. When handlers had long operations (45-second timeout simulations), the transaction held locks, causing:
- Other workers blocked when same command redelivered
- Lock contention during batch processing
- Workers hanging

## New Design

```
1. Handler executes (manages own transactions)
   ├── async with pool.connection()
   ├── Business logic...
   └── COMMIT (handler's transaction)
                    │
                    ▼
2. Worker completes command (separate transaction)
   ├── DELETE from PGMQ queue
   ├── UPDATE command status
   └── COMMIT
```

## Test plan

- [x] `make ready` passes
- [x] Unit tests pass (292 tests)
- [x] Integration tests pass (87 tests)
- [ ] E2E batch processing test

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)