### PR TITLE
feat: include response_data in reply messages

### DIFF
--- a/tests/e2e/app/handlers.py
+++ b/tests/e2e/app/handlers.py
@@ -128,6 +128,13 @@ class TestCommandHandlers:
 
         # Update attempt count and mark processed
         attempt = await repo.increment_attempts(cmd.command_id)
-        result = {"status": "success", "attempt": attempt}
+        result: dict[str, Any] = {"status": "success", "attempt": attempt}
+
+        # Include response_data if send_response is enabled
+        if behavior.get("send_response", False):
+            response_data = behavior.get("response_data", {})
+            if response_data:
+                result["response_data"] = response_data
+
         await repo.mark_processed(cmd.command_id, result)
         return result


### PR DESCRIPTION
## Summary

- Include `response_data` in reply when `send_response` behavior is enabled
- The handler now checks behavior config and includes `response_data` in result

## Test plan

- [ ] Create batch with `send_response: true` and `response_data: {"key": "value"}`
- [ ] Verify reply message contains the `response_data` in the result

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)