### PR TITLE
Add runtime config persistence

### DIFF
--- a/tests/e2e/app/api/schemas.py
+++ b/tests/e2e/app/api/schemas.py
@@ -1,6 +1,7 @@
 """Pydantic schema definitions for E2E API."""
 
 from datetime import date, datetime
+from enum import StrEnum
 from typing import Any
 from uuid import UUID
 
@@ -425,11 +426,26 @@ class RetryConfigSchema(BaseModel):
     backoff_schedule: list[int] = [10, 60, 300]
 
 
+class RuntimeMode(StrEnum):
+    """Runtime selection for E2E demo."""
+
+    ASYNC = "async"
+    SYNC = "sync"
+
+
+class RuntimeConfigSchema(BaseModel):
+    """Runtime configuration (async vs sync)."""
+
+    mode: RuntimeMode = RuntimeMode.ASYNC
+    thread_pool_size: int | None = Field(default=None, ge=1, le=64)
+
+
 class ConfigResponse(BaseModel):
     """Configuration response."""
 
     worker: WorkerConfigSchema
     retry: RetryConfigSchema
+    runtime: RuntimeConfigSchema
     error: str | None = None
 
 
@@ -438,6 +454,7 @@ class ConfigUpdateRequest(BaseModel):
 
     worker: WorkerConfigSchema | None = None
     retry: RetryConfigSchema | None = None
+    runtime: RuntimeConfigSchema | None = None
 
 
 class ConfigUpdateResponse(BaseModel):

--- a/tests/unit/test_config_store.py
+++ b/tests/unit/test_config_store.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.e2e.app.config import ConfigStore, RuntimeConfig
+
+
+class FakeCursor:
+    def __init__(self, rows: list[tuple[str, dict[str, Any]]] | None = None) -> None:
+        self.rows = rows or []
+        self.executed: list[tuple[str, Any | None]] = []
+
+    async def __aenter__(self) -> FakeCursor:
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        return None
+
+    async def execute(self, query: str, params: Any | None = None) -> None:
+        self.executed.append((query.strip(), params))
+
+    async def fetchall(self) -> list[tuple[str, dict[str, Any]]]:
+        return self.rows
+
+
+class FakeConnection:
+    def __init__(self, rows: list[tuple[str, dict[str, Any]]] | None = None) -> None:
+        self.cursor_impl = FakeCursor(rows)
+
+    async def __aenter__(self) -> FakeConnection:
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        return None
+
+    def cursor(self) -> FakeCursor:
+        return self.cursor_impl
+
+
+class FakePool:
+    def __init__(self, rows: list[tuple[str, dict[str, Any]]] | None = None) -> None:
+        self.connection_impl = FakeConnection(rows)
+
+    def connection(self) -> FakeConnection:
+        return self.connection_impl
+
+
+@pytest.mark.asyncio
+async def test_runtime_config_round_trip() -> None:
+    rows = [
+        ("worker", {"visibility_timeout": 45}),
+        ("retry", {"max_attempts": 4, "backoff_schedule": [5, 30]}),
+        ("runtime", {"mode": "sync", "thread_pool_size": 12}),
+    ]
+    pool = FakePool(rows)
+    store = ConfigStore()
+    await store.load_from_db(pool)  # type: ignore[arg-type]
+
+    assert store.runtime.mode == "sync"
+    assert store.runtime.thread_pool_size == 12
+
+    store.runtime = RuntimeConfig(mode="async", thread_pool_size=None)
+    await store.save_to_db(pool)  # type: ignore[arg-type]
+
+    # Validate that runtime row was persisted
+    cursor = pool.connection_impl.cursor_impl
+    runtime_statements = [stmt for stmt in cursor.executed if "VALUES ('runtime'" in stmt[0]]
+    assert runtime_statements, "runtime config should be upserted"


### PR DESCRIPTION
Summary:
- add RuntimeConfig schema + dataclass so /config GET/PUT and ConfigStore persist the async/sync runtime selection
- store runtime row alongside worker/retry in e2e.config, including thread pool size override
- add unit coverage for ConfigStore load/save round-trips and update FastAPI schema/response defaults

Testing:
- uv run pytest tests/unit --maxfail=1
- uv run mypy src
- uv run pre-commit run --all-files

Closes #222