### PR TITLE
feat: runtime-aware FastAPI dependencies

### DIFF
--- a/tests/e2e/app/dependencies.py
+++ b/tests/e2e/app/dependencies.py
@@ -10,6 +10,7 @@ from commandbus.ops.troubleshooting import TroubleshootingQueue
 from commandbus.process import ProcessRepository
 
 from .process.statement_report import StatementReportProcess
+from .runtime import RuntimeManager
 
 
 async def get_pool(request: Request) -> AsyncConnectionPool:
@@ -17,26 +18,40 @@ async def get_pool(request: Request) -> AsyncConnectionPool:
     return request.app.state.pool
 
 
-async def get_command_bus(request: Request) -> CommandBus:
-    """Get CommandBus instance from app state."""
-    return request.app.state.bus
+async def get_runtime_manager(request: Request) -> RuntimeManager:
+    """Get runtime manager from app state."""
+    manager = getattr(request.app.state, "runtime_manager", None)
+    if manager is None:  # pragma: no cover - defensive guard
+        raise RuntimeError("Runtime manager is not initialized")
+    return manager
+
+
+async def get_command_bus(
+    manager: Annotated[RuntimeManager, Depends(get_runtime_manager)],
+) -> CommandBus:
+    """Get CommandBus instance that respects runtime mode."""
+    return manager.command_bus
 
 
 async def get_tsq(
-    pool: Annotated[AsyncConnectionPool, Depends(get_pool)],
+    manager: Annotated[RuntimeManager, Depends(get_runtime_manager)],
 ) -> TroubleshootingQueue:
     """Get TroubleshootingQueue instance."""
-    return TroubleshootingQueue(pool)
+    return manager.troubleshooting_queue
 
 
-async def get_process_repo(request: Request) -> ProcessRepository:
-    """Get ProcessRepository from app state."""
-    return request.app.state.process_repo
+async def get_process_repo(
+    manager: Annotated[RuntimeManager, Depends(get_runtime_manager)],
+) -> ProcessRepository:
+    """Get ProcessRepository from runtime manager."""
+    return manager.process_repository
 
 
-async def get_report_process(request: Request) -> StatementReportProcess:
-    """Get StatementReportProcess from app state."""
-    return request.app.state.report_process
+async def get_report_process(
+    manager: Annotated[RuntimeManager, Depends(get_runtime_manager)],
+) -> StatementReportProcess:
+    """Get StatementReportProcess from runtime manager."""
+    return manager.report_process
 
 
 # Type aliases for cleaner route signatures

--- a/tests/e2e/app/runtime.py
+++ b/tests/e2e/app/runtime.py
@@ -1,0 +1,141 @@
+"""Runtime manager to toggle between async and sync command bus implementations."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+from commandbus import CommandBus, TroubleshootingQueue
+from commandbus.process import PostgresProcessRepository
+from commandbus.sync import SyncCommandBus, SyncRuntime, SyncTroubleshootingQueue
+
+from .config import RuntimeConfig
+from .models import TestCommandRepository
+from .process.statement_report import StatementReportProcess
+
+
+class _RuntimeAdapter:
+    """Wraps async objects and optionally dispatches to sync wrappers via a thread."""
+
+    def __init__(
+        self,
+        mode: str,
+        async_obj: Any,
+        sync_obj: Any | None = None,
+    ) -> None:
+        self._mode = mode
+        self._async_obj = async_obj
+        self._sync_obj = sync_obj
+
+    def __getattr__(self, item: str) -> Any:
+        attr = getattr(self._async_obj, item)
+        if self._mode != "sync" or self._sync_obj is None:
+            return attr
+
+        sync_attr = getattr(self._sync_obj, item, None)
+        if not callable(sync_attr):
+            return attr
+
+        async def _wrapper(*args: Any, **kwargs: Any) -> Any:
+            return await asyncio.to_thread(sync_attr, *args, **kwargs)
+
+        return _wrapper
+
+
+class RuntimeManager:
+    """Coordinates async and sync variants for FastAPI dependencies."""
+
+    def __init__(
+        self,
+        *,
+        pool: Any,
+        behavior_repo: TestCommandRepository,
+    ) -> None:
+        self._pool = pool
+        self._behavior_repo = behavior_repo
+        self._mode: str = "async"
+        self._runtime_config: RuntimeConfig | None = None
+        self._async_bus: CommandBus | None = None
+        self._async_tsq: TroubleshootingQueue | None = None
+        self._process_repo: PostgresProcessRepository | None = None
+        self._report_process: StatementReportProcess | None = None
+        self._bus_adapter: _RuntimeAdapter | None = None
+        self._tsq_adapter: _RuntimeAdapter | None = None
+        self._sync_runtime: SyncRuntime | None = None
+        self._sync_bus: SyncCommandBus | None = None
+        self._sync_tsq: SyncTroubleshootingQueue | None = None
+
+    async def start(self, runtime_config: RuntimeConfig) -> None:
+        """Initialize runtime resources based on configuration."""
+        await self.shutdown()
+        self._runtime_config = runtime_config
+        self._mode = runtime_config.mode
+        self._async_bus = CommandBus(self._pool)
+        self._async_tsq = TroubleshootingQueue(self._pool)
+        self._process_repo = PostgresProcessRepository(self._pool)
+
+        if self._mode == "sync":
+            self._sync_runtime = SyncRuntime()
+            self._sync_bus = SyncCommandBus(bus=self._async_bus, runtime=self._sync_runtime)
+            self._sync_tsq = SyncTroubleshootingQueue(
+                queue=self._async_tsq, runtime=self._sync_runtime
+            )
+
+        self._bus_adapter = _RuntimeAdapter(self._mode, self._async_bus, self._sync_bus)
+        self._tsq_adapter = _RuntimeAdapter(self._mode, self._async_tsq, self._sync_tsq)
+
+        self._report_process = StatementReportProcess(
+            command_bus=self._bus_adapter,
+            process_repo=self._process_repo,
+            reply_queue="reporting__process_replies",
+            pool=self._pool,
+            behavior_repo=self._behavior_repo,
+        )
+
+    async def reload_config(self, runtime_config: RuntimeConfig) -> None:
+        """Restart runtime resources with a new configuration."""
+        await self.start(runtime_config)
+
+    async def shutdown(self) -> None:
+        """Clean up runtime-specific resources."""
+        if self._sync_runtime is not None:
+            self._sync_runtime.shutdown()
+        self._bus_adapter = None
+        self._tsq_adapter = None
+        self._sync_runtime = None
+        self._sync_bus = None
+        self._sync_tsq = None
+        self._async_bus = None
+        self._async_tsq = None
+        self._process_repo = None
+        self._report_process = None
+
+    @property
+    def mode(self) -> str:
+        """Current runtime mode."""
+        return self._mode
+
+    @property
+    def runtime_config(self) -> RuntimeConfig | None:
+        """Most recent runtime configuration."""
+        return self._runtime_config
+
+    @property
+    def command_bus(self) -> CommandBus:
+        assert self._bus_adapter is not None
+        return cast("CommandBus", self._bus_adapter)
+
+    @property
+    def troubleshooting_queue(self) -> TroubleshootingQueue:
+        assert self._tsq_adapter is not None
+        return cast("TroubleshootingQueue", self._tsq_adapter)
+
+    @property
+    def process_repository(self) -> PostgresProcessRepository:
+        assert self._process_repo is not None
+        return self._process_repo
+
+    @property
+    def report_process(self) -> StatementReportProcess:
+        assert self._report_process is not None
+        return self._report_process

--- a/tests/e2e/tests/test_api.py
+++ b/tests/e2e/tests/test_api.py
@@ -1,0 +1,63 @@
+"""Integration tests for FastAPI runtime manager dependencies (S072)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from commandbus.models import CommandStatus
+from commandbus.sync import SyncCommandBus
+from tests.e2e.app.config import ConfigStore, RuntimeConfig
+from tests.e2e.app.models import TestCommandRepository
+from tests.e2e.app.runtime import RuntimeManager
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_commands_respect_runtime(
+    pool,
+    worker_task,
+    wait_for_completion,
+    cleanup_db,
+    monkeypatch,
+) -> None:
+    """Ensure runtime manager dispatches through sync wrappers when mode == sync."""
+    store = ConfigStore()
+    store.runtime = RuntimeConfig(mode="sync")
+    await store.save_to_db(pool)
+
+    sync_calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+
+    class InstrumentedSyncCommandBus(SyncCommandBus):
+        def send(self, *args, **kwargs):
+            sync_calls.append(("send", args, kwargs))
+            return super().send(*args, **kwargs)
+
+    monkeypatch.setattr("tests.e2e.app.runtime.SyncCommandBus", InstrumentedSyncCommandBus)
+
+    behavior_repo = TestCommandRepository(pool)
+    manager = RuntimeManager(pool=pool, behavior_repo=behavior_repo)
+    await manager.start(store.runtime)
+
+    command_id = uuid4()
+    await behavior_repo.create(command_id, behavior={}, payload={})
+
+    try:
+        await manager.command_bus.send(
+            domain="e2e",
+            command_type="TestCommand",
+            command_id=command_id,
+            data={"behavior": {}},
+            max_attempts=3,
+        )
+
+        cmd = await wait_for_completion(command_id, timeout=15)
+        assert cmd.status == CommandStatus.COMPLETED
+        assert sync_calls, "SyncCommandBus should be invoked in sync mode"
+    finally:
+        await manager.shutdown()
+        store.runtime = RuntimeConfig(mode="async")
+        await store.save_to_db(pool)
+        async with pool.connection() as conn:
+            await conn.execute("DELETE FROM e2e.test_command WHERE command_id = %s", (command_id,))

--- a/tests/unit/test_runtime_manager.py
+++ b/tests/unit/test_runtime_manager.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from tests.e2e.app.config import RuntimeConfig
+from tests.e2e.app.runtime import RuntimeManager
+
+
+@pytest.fixture
+def base_runtime_components(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
+    """Patch async components so RuntimeManager can run without a database."""
+    events: dict[str, list[Any]] = {
+        "async_bus_calls": [],
+        "async_tsq_calls": [],
+    }
+
+    class FakeCommandBus:
+        def __init__(self, pool: Any) -> None:
+            self.pool = pool
+
+        async def send(self, *args: Any, **kwargs: Any) -> str:
+            events["async_bus_calls"].append(("send", args, kwargs))
+            return "async-send"
+
+        async def send_batch(self, *args: Any, **kwargs: Any) -> str:
+            events["async_bus_calls"].append(("send_batch", args, kwargs))
+            return "async-batch"
+
+    class FakeTroubleshootingQueue:
+        def __init__(self, pool: Any) -> None:
+            self.pool = pool
+
+        async def list_all_troubleshooting(self, *args: Any, **kwargs: Any) -> str:
+            events["async_tsq_calls"].append(("list_all_troubleshooting", args, kwargs))
+            return "tsq-list"
+
+    class FakeProcessRepo:
+        def __init__(self, pool: Any) -> None:
+            self.pool = pool
+
+    class FakeReportProcess:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    monkeypatch.setattr("tests.e2e.app.runtime.CommandBus", FakeCommandBus)
+    monkeypatch.setattr("tests.e2e.app.runtime.TroubleshootingQueue", FakeTroubleshootingQueue)
+    monkeypatch.setattr("tests.e2e.app.runtime.PostgresProcessRepository", FakeProcessRepo)
+    monkeypatch.setattr("tests.e2e.app.runtime.StatementReportProcess", FakeReportProcess)
+    return events
+
+
+@pytest.mark.asyncio
+async def test_async_mode_reuses_async_components(
+    base_runtime_components: dict[str, list[Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Async mode should never instantiate sync wrappers."""
+
+    # Fail the test if sync wrappers get constructed
+    class FailSyncBus:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise AssertionError("SyncCommandBus should not be initialized for async mode")
+
+    class FailSyncTqs:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise AssertionError(
+                "SyncTroubleshootingQueue should not be initialized for async mode"
+            )
+
+    monkeypatch.setattr("tests.e2e.app.runtime.SyncCommandBus", FailSyncBus)
+    monkeypatch.setattr("tests.e2e.app.runtime.SyncTroubleshootingQueue", FailSyncTqs)
+
+    manager = RuntimeManager(pool=object(), behavior_repo=object())
+    await manager.start(RuntimeConfig(mode="async"))
+
+    await manager.command_bus.send(
+        domain="e2e",
+        command_type="TestCommand",
+        command_id=uuid4(),
+    )
+    await manager.troubleshooting_queue.list_all_troubleshooting()
+
+    assert base_runtime_components["async_bus_calls"]
+    assert base_runtime_components["async_tsq_calls"]
+
+
+@pytest.mark.asyncio
+async def test_sync_mode_routes_through_sync_wrappers(
+    base_runtime_components: dict[str, list[Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sync mode should execute via SyncCommandBus + asyncio.to_thread."""
+    sync_bus_calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+    sync_tsq_calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    class FakeSyncRuntime:
+        def shutdown(self) -> None:
+            return None
+
+    class FakeSyncBus:
+        def __init__(self, *, bus: Any, runtime: Any) -> None:
+            self.bus = bus
+            self.runtime = runtime
+
+        def send(self, *args: Any, **kwargs: Any) -> str:
+            sync_bus_calls.append(("send", args, kwargs))
+            return "sync-send"
+
+    class FakeSyncTqs:
+        def __init__(self, *, queue: Any, runtime: Any) -> None:
+            self.queue = queue
+            self.runtime = runtime
+
+        def list_all_troubleshooting(self, *args: Any, **kwargs: Any) -> str:
+            sync_tsq_calls.append(("list", args, kwargs))
+            return "sync-tsq"
+
+    async def fake_to_thread(func: Any, *args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr("tests.e2e.app.runtime.SyncRuntime", FakeSyncRuntime)
+    monkeypatch.setattr("tests.e2e.app.runtime.SyncCommandBus", FakeSyncBus)
+    monkeypatch.setattr("tests.e2e.app.runtime.SyncTroubleshootingQueue", FakeSyncTqs)
+    monkeypatch.setattr("tests.e2e.app.runtime.asyncio.to_thread", fake_to_thread)
+
+    manager = RuntimeManager(pool=object(), behavior_repo=object())
+    await manager.start(RuntimeConfig(mode="sync"))
+
+    result = await manager.command_bus.send(
+        domain="e2e",
+        command_type="TestCommand",
+        command_id=uuid4(),
+    )
+    tsq_result = await manager.troubleshooting_queue.list_all_troubleshooting()
+
+    assert result == "sync-send"
+    assert tsq_result == "sync-tsq"
+    assert sync_bus_calls
+    assert sync_tsq_calls
+    # Async components should not record direct usage in sync mode
+    assert not base_runtime_components["async_bus_calls"]
+    assert not base_runtime_components["async_tsq_calls"]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_clears_sync_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Shutdown should stop the SyncRuntime and drop adapters."""
+    shutdown_called = False
+
+    class FakeSyncRuntime:
+        def shutdown(self) -> None:
+            nonlocal shutdown_called
+            shutdown_called = True
+
+    class FakeSyncBus:
+        def __init__(self, *, bus: Any, runtime: Any) -> None:
+            self.runtime = runtime
+
+        def send(self, *args: Any, **kwargs: Any) -> str:
+            return "sync"
+
+    class FakeSyncTqs:
+        def __init__(self, *, queue: Any, runtime: Any) -> None:
+            self.runtime = runtime
+
+        def list_all_troubleshooting(self, *args: Any, **kwargs: Any) -> str:
+            return "sync-tsq"
+
+    class FakeCommandBus:
+        def __init__(self, pool: Any) -> None:
+            self.pool = pool
+
+        async def send(self, *args: Any, **kwargs: Any) -> str:
+            return "async"
+
+    class FakeTroubleshootingQueue:
+        def __init__(self, pool: Any) -> None:
+            self.pool = pool
+
+        async def list_all_troubleshooting(self, *args: Any, **kwargs: Any) -> str:
+            return "async-tsq"
+
+    class FakeProcessRepo:
+        def __init__(self, pool: Any) -> None:
+            self.pool = pool
+
+    class FakeReportProcess:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    async def fake_to_thread(func: Any, *args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr("tests.e2e.app.runtime.CommandBus", FakeCommandBus)
+    monkeypatch.setattr("tests.e2e.app.runtime.TroubleshootingQueue", FakeTroubleshootingQueue)
+    monkeypatch.setattr("tests.e2e.app.runtime.PostgresProcessRepository", FakeProcessRepo)
+    monkeypatch.setattr("tests.e2e.app.runtime.StatementReportProcess", FakeReportProcess)
+    monkeypatch.setattr("tests.e2e.app.runtime.SyncRuntime", FakeSyncRuntime)
+    monkeypatch.setattr("tests.e2e.app.runtime.SyncCommandBus", FakeSyncBus)
+    monkeypatch.setattr("tests.e2e.app.runtime.SyncTroubleshootingQueue", FakeSyncTqs)
+    monkeypatch.setattr("tests.e2e.app.runtime.asyncio.to_thread", fake_to_thread)
+
+    manager = RuntimeManager(pool=object(), behavior_repo=object())
+    await manager.start(RuntimeConfig(mode="sync"))
+
+    await manager.shutdown()
+
+    assert shutdown_called
+    with pytest.raises(AssertionError):
+        _ = manager.command_bus


### PR DESCRIPTION
Summary:
- add a RuntimeManager module and wire FastAPI lifespan/dependencies so runtime mode can flip between async and sync
- update dependency functions to reuse manager-provided bus/TSQ/process instances instead of reconstructing them per request
- add runtime manager unit coverage plus an e2e test proving sync mode runs commands through the new facades

Testing:
- .venv/bin/ruff format src tests
- .venv/bin/ruff check src tests
- .venv/bin/mypy src
- .venv/bin/pytest tests/unit --cov=src/commandbus --cov-branch --cov-fail-under=80 -q

Closes #224