### PR TITLE
feat: Extract shared SQL core for sync/async implementations

### DIFF
--- a/src/commandbus/_core/__init__.py
+++ b/src/commandbus/_core/__init__.py
@@ -1,0 +1,21 @@
+"""Shared SQL core for async and sync implementations.
+
+This module contains SQL constants, parameter builders, and row parsers
+that are shared between async and sync repository implementations.
+"""
+
+from commandbus._core.batch_sql import BatchParams, BatchParsers, BatchSQL
+from commandbus._core.command_sql import CommandParams, CommandParsers, CommandSQL
+from commandbus._core.pgmq_sql import PgmqParams, PgmqParsers, PgmqSQL
+
+__all__ = [
+    "BatchParams",
+    "BatchParsers",
+    "BatchSQL",
+    "CommandParams",
+    "CommandParsers",
+    "CommandSQL",
+    "PgmqParams",
+    "PgmqParsers",
+    "PgmqSQL",
+]

--- a/src/commandbus/_core/batch_sql.py
+++ b/src/commandbus/_core/batch_sql.py
@@ -1,0 +1,185 @@
+"""SQL constants, parameter builders, and row parsers for batch operations.
+
+This module extracts shared SQL logic for both async and sync implementations.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from commandbus.models import BatchMetadata, BatchStatus
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+
+class BatchSQL:
+    """SQL constants for batch operations."""
+
+    # Column order for SELECT queries
+    SELECT_COLUMNS = """
+        domain, batch_id, name, custom_data, status,
+        total_count, completed_count,
+        canceled_count, in_troubleshooting_count,
+        created_at, started_at, completed_at
+    """
+
+    SAVE = """
+        INSERT INTO commandbus.batch (
+            domain, batch_id, name, custom_data, status,
+            total_count, completed_count,
+            canceled_count, in_troubleshooting_count,
+            created_at, started_at, completed_at
+        ) VALUES (%s, %s, %s, %s::jsonb, %s, %s, %s, %s, %s, %s, %s, %s)
+    """
+
+    GET = f"""
+        SELECT {SELECT_COLUMNS}
+        FROM commandbus.batch
+        WHERE domain = %s AND batch_id = %s
+    """
+
+    EXISTS = """
+        SELECT EXISTS(
+            SELECT 1 FROM commandbus.batch
+            WHERE domain = %s AND batch_id = %s
+        )
+    """
+
+    LIST = f"""
+        SELECT {SELECT_COLUMNS}
+        FROM commandbus.batch
+        WHERE domain = %s
+        ORDER BY created_at DESC
+        LIMIT %s OFFSET %s
+    """
+
+    LIST_WITH_STATUS = f"""
+        SELECT {SELECT_COLUMNS}
+        FROM commandbus.batch
+        WHERE domain = %s AND status = %s
+        ORDER BY created_at DESC
+        LIMIT %s OFFSET %s
+    """
+
+    # Stored procedure calls for TSQ operations
+    SP_TSQ_COMPLETE = "SELECT commandbus.sp_tsq_complete(%s, %s)"
+    SP_TSQ_CANCEL = "SELECT commandbus.sp_tsq_cancel(%s, %s)"
+    SP_TSQ_RETRY = "SELECT commandbus.sp_tsq_retry(%s, %s)"
+
+
+class BatchParams:
+    """Static methods for building SQL parameter tuples."""
+
+    @staticmethod
+    def save(metadata: BatchMetadata) -> tuple[Any, ...]:
+        """Build parameters for SAVE query.
+
+        Args:
+            metadata: Batch metadata to save
+
+        Returns:
+            Tuple of 12 parameters for SAVE SQL
+        """
+        custom_data_json = json.dumps(metadata.custom_data) if metadata.custom_data else None
+        return (
+            metadata.domain,
+            metadata.batch_id,
+            metadata.name,
+            custom_data_json,
+            metadata.status.value,
+            metadata.total_count,
+            metadata.completed_count,
+            metadata.canceled_count,
+            metadata.in_troubleshooting_count,
+            metadata.created_at,
+            metadata.started_at,
+            metadata.completed_at,
+        )
+
+    @staticmethod
+    def get(domain: str, batch_id: UUID) -> tuple[str, UUID]:
+        """Build parameters for GET query."""
+        return (domain, batch_id)
+
+    @staticmethod
+    def exists(domain: str, batch_id: UUID) -> tuple[str, UUID]:
+        """Build parameters for EXISTS query."""
+        return (domain, batch_id)
+
+    @staticmethod
+    def list_batches(
+        domain: str,
+        limit: int,
+        offset: int,
+    ) -> tuple[str, int, int]:
+        """Build parameters for LIST query."""
+        return (domain, limit, offset)
+
+    @staticmethod
+    def list_batches_with_status(
+        domain: str,
+        status: BatchStatus | str,
+        limit: int,
+        offset: int,
+    ) -> tuple[str, str, int, int]:
+        """Build parameters for LIST_WITH_STATUS query."""
+        status_value = status.value if isinstance(status, BatchStatus) else status
+        return (domain, status_value, limit, offset)
+
+    @staticmethod
+    def tsq_operation(domain: str, batch_id: UUID) -> tuple[str, UUID]:
+        """Build parameters for TSQ stored procedure calls."""
+        return (domain, batch_id)
+
+
+class BatchParsers:
+    """Static methods for parsing database rows to BatchMetadata."""
+
+    @staticmethod
+    def from_row(row: tuple[Any, ...]) -> BatchMetadata:
+        """Parse a database row to BatchMetadata.
+
+        Expected column order (12 fields):
+            domain, batch_id, name, custom_data, status,
+            total_count, completed_count,
+            canceled_count, in_troubleshooting_count,
+            created_at, started_at, completed_at
+
+        Args:
+            row: Database row tuple
+
+        Returns:
+            BatchMetadata instance
+        """
+        custom_data = row[3]
+        if isinstance(custom_data, str):
+            custom_data = json.loads(custom_data)
+
+        return BatchMetadata(
+            domain=row[0],
+            batch_id=row[1],
+            name=row[2],
+            custom_data=custom_data,
+            status=BatchStatus(row[4]),
+            total_count=row[5],
+            completed_count=row[6],
+            canceled_count=row[7],
+            in_troubleshooting_count=row[8],
+            created_at=row[9],
+            started_at=row[10],
+            completed_at=row[11],
+        )
+
+    @staticmethod
+    def from_rows(rows: list[tuple[Any, ...]]) -> list[BatchMetadata]:
+        """Parse multiple database rows to BatchMetadata list.
+
+        Args:
+            rows: List of database row tuples
+
+        Returns:
+            List of BatchMetadata instances
+        """
+        return [BatchParsers.from_row(row) for row in rows]

--- a/src/commandbus/_core/command_sql.py
+++ b/src/commandbus/_core/command_sql.py
@@ -1,0 +1,304 @@
+"""SQL constants, parameter builders, and row parsers for command operations.
+
+This module extracts shared SQL logic for both async and sync implementations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from commandbus.models import CommandMetadata, CommandStatus
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+
+class CommandSQL:
+    """SQL constants for command operations."""
+
+    # Column order for SELECT queries - used by all GET/RECEIVE operations
+    SELECT_COLUMNS = """
+        domain, command_id, command_type, status, attempts,
+        max_attempts, msg_id, correlation_id, reply_queue,
+        last_error_type, last_error_code, last_error_msg,
+        created_at, updated_at, batch_id
+    """
+
+    SAVE = """
+        INSERT INTO commandbus.command (
+            domain, queue_name, msg_id, command_id, command_type,
+            status, attempts, max_attempts, correlation_id, reply_queue,
+            created_at, updated_at, batch_id
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    """
+
+    GET = f"""
+        SELECT {SELECT_COLUMNS}
+        FROM commandbus.command
+        WHERE domain = %s AND command_id = %s
+    """
+
+    UPDATE_STATUS = """
+        UPDATE commandbus.command
+        SET status = %s, updated_at = NOW()
+        WHERE domain = %s AND command_id = %s
+    """
+
+    UPDATE_MSG_ID = """
+        UPDATE commandbus.command
+        SET msg_id = %s, updated_at = NOW()
+        WHERE domain = %s AND command_id = %s
+    """
+
+    INCREMENT_ATTEMPTS = """
+        UPDATE commandbus.command
+        SET attempts = attempts + 1, updated_at = NOW()
+        WHERE domain = %s AND command_id = %s
+        RETURNING attempts
+    """
+
+    RECEIVE_COMMAND = f"""
+        UPDATE commandbus.command
+        SET attempts = attempts + 1,
+            status = %s,
+            updated_at = NOW()
+        WHERE domain = %s AND command_id = %s
+          AND status NOT IN ('COMPLETED', 'CANCELED')
+        RETURNING {SELECT_COLUMNS}
+    """
+
+    UPDATE_ERROR = """
+        UPDATE commandbus.command
+        SET last_error_type = %s, last_error_code = %s, last_error_msg = %s,
+            updated_at = NOW()
+        WHERE domain = %s AND command_id = %s
+    """
+
+    FINISH_COMMAND = """
+        UPDATE commandbus.command
+        SET status = %s,
+            last_error_type = COALESCE(%s, last_error_type),
+            last_error_code = COALESCE(%s, last_error_code),
+            last_error_msg = COALESCE(%s, last_error_msg),
+            updated_at = NOW()
+        WHERE domain = %s AND command_id = %s
+    """
+
+    EXISTS = """
+        SELECT EXISTS(
+            SELECT 1 FROM commandbus.command
+            WHERE domain = %s AND command_id = %s
+        )
+    """
+
+    EXISTS_BATCH = """
+        SELECT command_id FROM commandbus.command
+        WHERE domain = %s AND command_id = ANY(%s)
+    """
+
+    LIST_BY_BATCH = f"""
+        SELECT {SELECT_COLUMNS}
+        FROM commandbus.command
+        WHERE domain = %s AND batch_id = %s
+        ORDER BY created_at ASC
+        LIMIT %s OFFSET %s
+    """
+
+    LIST_BY_BATCH_WITH_STATUS = f"""
+        SELECT {SELECT_COLUMNS}
+        FROM commandbus.command
+        WHERE domain = %s AND batch_id = %s AND status = %s
+        ORDER BY created_at ASC
+        LIMIT %s OFFSET %s
+    """
+
+    # Stored procedure calls
+    SP_RECEIVE_COMMAND = "SELECT * FROM commandbus.sp_receive_command(%s, %s, %s, %s, %s)"
+
+    SP_FINISH_COMMAND = (
+        "SELECT commandbus.sp_finish_command(%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s)"
+    )
+
+    SP_FAIL_COMMAND = "SELECT commandbus.sp_fail_command(%s, %s, %s, %s, %s, %s, %s, %s)"
+
+
+class CommandParams:
+    """Static methods for building SQL parameter tuples."""
+
+    @staticmethod
+    def save(metadata: CommandMetadata, queue_name: str) -> tuple[Any, ...]:
+        """Build parameters for SAVE query.
+
+        Args:
+            metadata: Command metadata to save
+            queue_name: The queue name for this command
+
+        Returns:
+            Tuple of 13 parameters for SAVE SQL
+        """
+        return (
+            metadata.domain,
+            queue_name,
+            metadata.msg_id,
+            metadata.command_id,
+            metadata.command_type,
+            metadata.status.value,
+            metadata.attempts,
+            metadata.max_attempts,
+            metadata.correlation_id,
+            metadata.reply_to or "",
+            metadata.created_at,
+            metadata.updated_at,
+            metadata.batch_id,
+        )
+
+    @staticmethod
+    def update_status(
+        status: CommandStatus, domain: str, command_id: UUID
+    ) -> tuple[str, str, UUID]:
+        """Build parameters for UPDATE_STATUS query."""
+        return (status.value, domain, command_id)
+
+    @staticmethod
+    def update_msg_id(msg_id: int, domain: str, command_id: UUID) -> tuple[int, str, UUID]:
+        """Build parameters for UPDATE_MSG_ID query."""
+        return (msg_id, domain, command_id)
+
+    @staticmethod
+    def receive_command(
+        new_status: CommandStatus, domain: str, command_id: UUID
+    ) -> tuple[str, str, UUID]:
+        """Build parameters for RECEIVE_COMMAND query."""
+        return (new_status.value, domain, command_id)
+
+    @staticmethod
+    def update_error(
+        error_type: str,
+        error_code: str,
+        error_msg: str,
+        domain: str,
+        command_id: UUID,
+    ) -> tuple[str, str, str, str, UUID]:
+        """Build parameters for UPDATE_ERROR query."""
+        return (error_type, error_code, error_msg, domain, command_id)
+
+    @staticmethod
+    def finish_command(
+        status: CommandStatus,
+        error_type: str | None,
+        error_code: str | None,
+        error_msg: str | None,
+        domain: str,
+        command_id: UUID,
+    ) -> tuple[str, str | None, str | None, str | None, str, UUID]:
+        """Build parameters for FINISH_COMMAND query."""
+        return (status.value, error_type, error_code, error_msg, domain, command_id)
+
+    @staticmethod
+    def sp_receive_command(
+        domain: str,
+        command_id: UUID,
+        new_status: str = "IN_PROGRESS",
+        msg_id: int | None = None,
+        max_attempts: int | None = None,
+    ) -> tuple[str, UUID, str, int | None, int | None]:
+        """Build parameters for SP_RECEIVE_COMMAND call."""
+        return (domain, command_id, new_status, msg_id, max_attempts)
+
+    @staticmethod
+    def sp_finish_command(
+        domain: str,
+        command_id: UUID,
+        status: CommandStatus,
+        event_type: str,
+        error_type: str | None,
+        error_code: str | None,
+        error_msg: str | None,
+        details_json: str | None,
+        batch_id: UUID | None,
+    ) -> tuple[str, UUID, str, str, str | None, str | None, str | None, str | None, UUID | None]:
+        """Build parameters for SP_FINISH_COMMAND call."""
+        return (
+            domain,
+            command_id,
+            status.value,
+            event_type,
+            error_type,
+            error_code,
+            error_msg,
+            details_json,
+            batch_id,
+        )
+
+    @staticmethod
+    def sp_fail_command(
+        domain: str,
+        command_id: UUID,
+        error_type: str,
+        error_code: str,
+        error_msg: str,
+        attempt: int,
+        max_attempts: int,
+        msg_id: int,
+    ) -> tuple[str, UUID, str, str, str, int, int, int]:
+        """Build parameters for SP_FAIL_COMMAND call."""
+        return (
+            domain,
+            command_id,
+            error_type,
+            error_code,
+            error_msg,
+            attempt,
+            max_attempts,
+            msg_id,
+        )
+
+
+class CommandParsers:
+    """Static methods for parsing database rows to CommandMetadata."""
+
+    @staticmethod
+    def from_row(row: tuple[Any, ...]) -> CommandMetadata:
+        """Parse a database row to CommandMetadata.
+
+        Expected column order (15 fields):
+            domain, command_id, command_type, status, attempts,
+            max_attempts, msg_id, correlation_id, reply_queue,
+            last_error_type, last_error_code, last_error_msg,
+            created_at, updated_at, batch_id
+
+        Args:
+            row: Database row tuple
+
+        Returns:
+            CommandMetadata instance
+        """
+        return CommandMetadata(
+            domain=row[0],
+            command_id=row[1],
+            command_type=row[2],
+            status=CommandStatus(row[3]),
+            attempts=row[4],
+            max_attempts=row[5],
+            msg_id=row[6],
+            correlation_id=row[7],
+            reply_to=row[8] if row[8] else None,
+            last_error_type=row[9],
+            last_error_code=row[10],
+            last_error_msg=row[11],
+            created_at=row[12],
+            updated_at=row[13],
+            batch_id=row[14],
+        )
+
+    @staticmethod
+    def from_rows(rows: list[tuple[Any, ...]]) -> list[CommandMetadata]:
+        """Parse multiple database rows to CommandMetadata list.
+
+        Args:
+            rows: List of database row tuples
+
+        Returns:
+            List of CommandMetadata instances
+        """
+        return [CommandParsers.from_row(row) for row in rows]

--- a/src/commandbus/_core/pgmq_sql.py
+++ b/src/commandbus/_core/pgmq_sql.py
@@ -1,0 +1,188 @@
+"""SQL constants, parameter builders, and row parsers for PGMQ operations.
+
+This module extracts shared SQL logic for both async and sync implementations.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+# Channel name prefix for pg_notify - shared between implementations
+PGMQ_NOTIFY_CHANNEL = "pgmq_notify"
+
+
+@dataclass
+class PgmqMessage:
+    """A message from a PGMQ queue.
+
+    Attributes:
+        msg_id: Unique message ID
+        read_count: Number of times message has been read
+        enqueued_at: When the message was enqueued
+        vt: Visibility timeout timestamp
+        message: The message payload
+    """
+
+    msg_id: int
+    read_count: int
+    enqueued_at: str
+    vt: str
+    message: dict[str, Any]
+
+
+class PgmqSQL:
+    """SQL constants for PGMQ operations."""
+
+    CREATE_QUEUE = "SELECT pgmq.create(%s)"
+
+    SEND = "SELECT pgmq.send(%s, %s::jsonb, %s)"
+
+    SEND_BATCH = "SELECT * FROM pgmq.send_batch(%s, %s::jsonb[], %s)"
+
+    READ = "SELECT * FROM pgmq.read(%s, %s, %s)"
+
+    DELETE = "SELECT pgmq.delete(%s, %s)"
+
+    ARCHIVE = "SELECT pgmq.archive(%s, %s)"
+
+    SET_VT = "SELECT * FROM pgmq.set_vt(%s, %s, %s)"
+
+    @staticmethod
+    def notify_channel(queue_name: str) -> str:
+        """Get the NOTIFY channel name for a queue.
+
+        Args:
+            queue_name: Name of the queue
+
+        Returns:
+            Channel name in format 'pgmq_notify_{queue_name}'
+        """
+        return f"{PGMQ_NOTIFY_CHANNEL}_{queue_name}"
+
+    @staticmethod
+    def notify_sql(queue_name: str) -> str:
+        """Get the NOTIFY SQL for a queue.
+
+        Args:
+            queue_name: Name of the queue
+
+        Returns:
+            SQL string like 'NOTIFY pgmq_notify_myqueue'
+        """
+        channel = PgmqSQL.notify_channel(queue_name)
+        return f"NOTIFY {channel}"
+
+
+class PgmqParams:
+    """Static methods for building SQL parameter tuples."""
+
+    @staticmethod
+    def create_queue(queue_name: str) -> tuple[str]:
+        """Build parameters for CREATE_QUEUE call."""
+        return (queue_name,)
+
+    @staticmethod
+    def send(queue_name: str, message: dict[str, Any], delay: int = 0) -> tuple[str, str, int]:
+        """Build parameters for SEND call.
+
+        Args:
+            queue_name: Name of the queue
+            message: Message payload (will be JSON serialized)
+            delay: Delay in seconds before message becomes visible
+
+        Returns:
+            Tuple of (queue_name, json_message, delay)
+        """
+        msg_json = json.dumps(message)
+        return (queue_name, msg_json, delay)
+
+    @staticmethod
+    def send_batch(
+        queue_name: str, messages: list[dict[str, Any]], delay: int = 0
+    ) -> tuple[str, list[str], int]:
+        """Build parameters for SEND_BATCH call.
+
+        Args:
+            queue_name: Name of the queue
+            messages: List of message payloads (will be JSON serialized)
+            delay: Delay in seconds before messages become visible
+
+        Returns:
+            Tuple of (queue_name, json_messages_list, delay)
+        """
+        msgs_json = [json.dumps(m) for m in messages]
+        return (queue_name, msgs_json, delay)
+
+    @staticmethod
+    def read(
+        queue_name: str, visibility_timeout: int = 30, batch_size: int = 1
+    ) -> tuple[str, int, int]:
+        """Build parameters for READ call.
+
+        Args:
+            queue_name: Name of the queue
+            visibility_timeout: Seconds before message becomes visible again
+            batch_size: Maximum number of messages to read
+
+        Returns:
+            Tuple of (queue_name, visibility_timeout, batch_size)
+        """
+        return (queue_name, visibility_timeout, batch_size)
+
+    @staticmethod
+    def delete(queue_name: str, msg_id: int) -> tuple[str, int]:
+        """Build parameters for DELETE call."""
+        return (queue_name, msg_id)
+
+    @staticmethod
+    def archive(queue_name: str, msg_id: int) -> tuple[str, int]:
+        """Build parameters for ARCHIVE call."""
+        return (queue_name, msg_id)
+
+    @staticmethod
+    def set_vt(queue_name: str, msg_id: int, visibility_timeout: int) -> tuple[str, int, int]:
+        """Build parameters for SET_VT call."""
+        return (queue_name, msg_id, visibility_timeout)
+
+
+class PgmqParsers:
+    """Static methods for parsing database rows to PgmqMessage."""
+
+    @staticmethod
+    def from_row(row: tuple[Any, ...]) -> PgmqMessage:
+        """Parse a database row to PgmqMessage.
+
+        Expected column order (5 fields):
+            msg_id, read_ct, enqueued_at, vt, message
+
+        Args:
+            row: Database row tuple
+
+        Returns:
+            PgmqMessage instance
+        """
+        message = row[4]
+        if isinstance(message, str):
+            message = json.loads(message)
+
+        return PgmqMessage(
+            msg_id=row[0],
+            read_count=row[1],
+            enqueued_at=str(row[2]),
+            vt=str(row[3]),
+            message=message,
+        )
+
+    @staticmethod
+    def from_rows(rows: list[tuple[Any, ...]]) -> list[PgmqMessage]:
+        """Parse multiple database rows to PgmqMessage list.
+
+        Args:
+            rows: List of database row tuples
+
+        Returns:
+            List of PgmqMessage instances
+        """
+        return [PgmqParsers.from_row(row) for row in rows]

--- a/tests/unit/core/__init__.py
+++ b/tests/unit/core/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for commandbus._core module."""

--- a/tests/unit/core/test_batch_sql.py
+++ b/tests/unit/core/test_batch_sql.py
@@ -1,0 +1,289 @@
+"""Unit tests for commandbus._core.batch_sql module."""
+
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+
+from commandbus._core.batch_sql import BatchParams, BatchParsers, BatchSQL
+from commandbus.models import BatchMetadata, BatchStatus
+
+
+class TestBatchSQL:
+    """Tests for BatchSQL class."""
+
+    def test_select_columns_defined(self) -> None:
+        """SELECT_COLUMNS should contain expected column list."""
+        assert "domain" in BatchSQL.SELECT_COLUMNS
+        assert "batch_id" in BatchSQL.SELECT_COLUMNS
+        assert "name" in BatchSQL.SELECT_COLUMNS
+        assert "custom_data" in BatchSQL.SELECT_COLUMNS
+        assert "status" in BatchSQL.SELECT_COLUMNS
+
+    def test_save_sql_has_correct_placeholders(self) -> None:
+        """SAVE SQL should have 12 placeholders."""
+        assert BatchSQL.SAVE.count("%s") == 12
+
+    def test_get_sql_has_placeholders(self) -> None:
+        """GET SQL should have 2 placeholders for domain and batch_id."""
+        assert BatchSQL.GET.count("%s") == 2
+
+    def test_exists_sql_has_placeholders(self) -> None:
+        """EXISTS SQL should have 2 placeholders."""
+        assert BatchSQL.EXISTS.count("%s") == 2
+
+    def test_list_sql_has_placeholders(self) -> None:
+        """LIST SQL should have 3 placeholders."""
+        assert BatchSQL.LIST.count("%s") == 3
+
+    def test_list_with_status_sql_has_placeholders(self) -> None:
+        """LIST_WITH_STATUS SQL should have 4 placeholders."""
+        assert BatchSQL.LIST_WITH_STATUS.count("%s") == 4
+
+    def test_sp_tsq_complete_has_placeholders(self) -> None:
+        """SP_TSQ_COMPLETE SQL should have 2 placeholders."""
+        assert BatchSQL.SP_TSQ_COMPLETE.count("%s") == 2
+
+    def test_sp_tsq_cancel_has_placeholders(self) -> None:
+        """SP_TSQ_CANCEL SQL should have 2 placeholders."""
+        assert BatchSQL.SP_TSQ_CANCEL.count("%s") == 2
+
+    def test_sp_tsq_retry_has_placeholders(self) -> None:
+        """SP_TSQ_RETRY SQL should have 2 placeholders."""
+        assert BatchSQL.SP_TSQ_RETRY.count("%s") == 2
+
+
+class TestBatchParams:
+    """Tests for BatchParams class."""
+
+    @pytest.fixture
+    def sample_metadata(self) -> BatchMetadata:
+        """Create sample BatchMetadata for testing."""
+        return BatchMetadata(
+            domain="test",
+            batch_id=uuid4(),
+            name="Test Batch",
+            custom_data={"key": "value"},
+            status=BatchStatus.PENDING,
+            total_count=10,
+            completed_count=0,
+            canceled_count=0,
+            in_troubleshooting_count=0,
+            created_at=datetime(2024, 1, 1, 12, 0, 0),
+            started_at=None,
+            completed_at=None,
+        )
+
+    def test_save_returns_correct_tuple_length(self, sample_metadata: BatchMetadata) -> None:
+        """save() should return 12 parameters."""
+        params = BatchParams.save(sample_metadata)
+        assert len(params) == 12
+
+    def test_save_returns_correct_values(self, sample_metadata: BatchMetadata) -> None:
+        """save() should return values in correct order."""
+        params = BatchParams.save(sample_metadata)
+
+        assert params[0] == sample_metadata.domain
+        assert params[1] == sample_metadata.batch_id
+        assert params[2] == sample_metadata.name
+        assert params[3] == '{"key": "value"}'  # JSON serialized
+        assert params[4] == sample_metadata.status.value
+        assert params[5] == sample_metadata.total_count
+        assert params[6] == sample_metadata.completed_count
+        assert params[7] == sample_metadata.canceled_count
+        assert params[8] == sample_metadata.in_troubleshooting_count
+        assert params[9] == sample_metadata.created_at
+        assert params[10] == sample_metadata.started_at
+        assert params[11] == sample_metadata.completed_at
+
+    def test_save_handles_none_custom_data(self, sample_metadata: BatchMetadata) -> None:
+        """save() should handle None custom_data."""
+        sample_metadata.custom_data = None
+        params = BatchParams.save(sample_metadata)
+        assert params[3] is None
+
+    def test_get_returns_correct_tuple(self) -> None:
+        """get() should return 2 parameters."""
+        batch_id = uuid4()
+        params = BatchParams.get("test", batch_id)
+
+        assert params == ("test", batch_id)
+
+    def test_exists_returns_correct_tuple(self) -> None:
+        """exists() should return 2 parameters."""
+        batch_id = uuid4()
+        params = BatchParams.exists("test", batch_id)
+
+        assert params == ("test", batch_id)
+
+    def test_list_batches_returns_correct_tuple(self) -> None:
+        """list_batches() should return 3 parameters."""
+        params = BatchParams.list_batches("test", 100, 0)
+
+        assert params == ("test", 100, 0)
+
+    def test_list_batches_with_status_returns_correct_tuple(self) -> None:
+        """list_batches_with_status() should return 4 parameters."""
+        params = BatchParams.list_batches_with_status("test", BatchStatus.PENDING, 100, 0)
+
+        assert params == ("test", "PENDING", 100, 0)
+
+    def test_list_batches_with_status_accepts_string(self) -> None:
+        """list_batches_with_status() should accept string status."""
+        params = BatchParams.list_batches_with_status("test", "COMPLETED", 50, 10)
+
+        assert params == ("test", "COMPLETED", 50, 10)
+
+    def test_tsq_operation_returns_correct_tuple(self) -> None:
+        """tsq_operation() should return 2 parameters."""
+        batch_id = uuid4()
+        params = BatchParams.tsq_operation("test", batch_id)
+
+        assert params == ("test", batch_id)
+
+
+class TestBatchParsers:
+    """Tests for BatchParsers class."""
+
+    def test_from_row_creates_metadata(self) -> None:
+        """from_row() should create BatchMetadata from tuple."""
+        batch_id = uuid4()
+        created_at = datetime(2024, 1, 1, 12, 0, 0)
+        started_at = datetime(2024, 1, 1, 12, 1, 0)
+        completed_at = datetime(2024, 1, 1, 12, 30, 0)
+
+        row = (
+            "test",  # domain
+            batch_id,  # batch_id
+            "Test Batch",  # name
+            {"key": "value"},  # custom_data (already parsed dict)
+            "COMPLETED",  # status
+            10,  # total_count
+            9,  # completed_count
+            1,  # canceled_count
+            0,  # in_troubleshooting_count
+            created_at,  # created_at
+            started_at,  # started_at
+            completed_at,  # completed_at
+        )
+
+        metadata = BatchParsers.from_row(row)
+
+        assert metadata.domain == "test"
+        assert metadata.batch_id == batch_id
+        assert metadata.name == "Test Batch"
+        assert metadata.custom_data == {"key": "value"}
+        assert metadata.status == BatchStatus.COMPLETED
+        assert metadata.total_count == 10
+        assert metadata.completed_count == 9
+        assert metadata.canceled_count == 1
+        assert metadata.in_troubleshooting_count == 0
+        assert metadata.created_at == created_at
+        assert metadata.started_at == started_at
+        assert metadata.completed_at == completed_at
+
+    def test_from_row_handles_string_custom_data(self) -> None:
+        """from_row() should parse JSON string custom_data."""
+        row = (
+            "test",
+            uuid4(),
+            "Test Batch",
+            '{"key": "value", "nested": {"a": 1}}',  # JSON string
+            "PENDING",
+            5,
+            0,
+            0,
+            0,
+            datetime.now(),
+            None,
+            None,
+        )
+
+        metadata = BatchParsers.from_row(row)
+
+        assert metadata.custom_data == {"key": "value", "nested": {"a": 1}}
+
+    def test_from_row_handles_none_custom_data(self) -> None:
+        """from_row() should handle None custom_data."""
+        row = (
+            "test",
+            uuid4(),
+            None,
+            None,  # None custom_data
+            "PENDING",
+            5,
+            0,
+            0,
+            0,
+            datetime.now(),
+            None,
+            None,
+        )
+
+        metadata = BatchParsers.from_row(row)
+        assert metadata.custom_data is None
+
+    def test_from_row_handles_all_statuses(self) -> None:
+        """from_row() should handle all BatchStatus values."""
+        for status in BatchStatus:
+            row = (
+                "test",
+                uuid4(),
+                "Test",
+                None,
+                status.value,
+                10,
+                0,
+                0,
+                0,
+                datetime.now(),
+                None,
+                None,
+            )
+
+            metadata = BatchParsers.from_row(row)
+            assert metadata.status == status
+
+    def test_from_rows_creates_list(self) -> None:
+        """from_rows() should create list of BatchMetadata."""
+        rows = [
+            (
+                "test",
+                uuid4(),
+                "Batch 1",
+                None,
+                "PENDING",
+                5,
+                0,
+                0,
+                0,
+                datetime.now(),
+                None,
+                None,
+            ),
+            (
+                "test",
+                uuid4(),
+                "Batch 2",
+                None,
+                "COMPLETED",
+                10,
+                10,
+                0,
+                0,
+                datetime.now(),
+                datetime.now(),
+                datetime.now(),
+            ),
+        ]
+
+        metadata_list = BatchParsers.from_rows(rows)
+
+        assert len(metadata_list) == 2
+        assert metadata_list[0].name == "Batch 1"
+        assert metadata_list[1].name == "Batch 2"
+
+    def test_from_rows_handles_empty_list(self) -> None:
+        """from_rows() should handle empty list."""
+        metadata_list = BatchParsers.from_rows([])
+        assert metadata_list == []

--- a/tests/unit/core/test_command_sql.py
+++ b/tests/unit/core/test_command_sql.py
@@ -1,0 +1,385 @@
+"""Unit tests for commandbus._core.command_sql module."""
+
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+
+from commandbus._core.command_sql import CommandParams, CommandParsers, CommandSQL
+from commandbus.models import CommandMetadata, CommandStatus
+
+
+class TestCommandSQL:
+    """Tests for CommandSQL class."""
+
+    def test_select_columns_defined(self) -> None:
+        """SELECT_COLUMNS should contain expected column list."""
+        assert "domain" in CommandSQL.SELECT_COLUMNS
+        assert "command_id" in CommandSQL.SELECT_COLUMNS
+        assert "command_type" in CommandSQL.SELECT_COLUMNS
+        assert "status" in CommandSQL.SELECT_COLUMNS
+        assert "batch_id" in CommandSQL.SELECT_COLUMNS
+
+    def test_save_sql_has_correct_placeholders(self) -> None:
+        """SAVE SQL should have 13 placeholders."""
+        assert CommandSQL.SAVE.count("%s") == 13
+
+    def test_get_sql_has_placeholders(self) -> None:
+        """GET SQL should have 2 placeholders for domain and command_id."""
+        assert CommandSQL.GET.count("%s") == 2
+
+    def test_update_status_sql_has_placeholders(self) -> None:
+        """UPDATE_STATUS SQL should have 3 placeholders."""
+        assert CommandSQL.UPDATE_STATUS.count("%s") == 3
+
+    def test_receive_command_sql_has_placeholders(self) -> None:
+        """RECEIVE_COMMAND SQL should have 3 placeholders."""
+        assert CommandSQL.RECEIVE_COMMAND.count("%s") == 3
+
+    def test_finish_command_sql_has_placeholders(self) -> None:
+        """FINISH_COMMAND SQL should have 6 placeholders."""
+        assert CommandSQL.FINISH_COMMAND.count("%s") == 6
+
+    def test_exists_sql_has_placeholders(self) -> None:
+        """EXISTS SQL should have 2 placeholders."""
+        assert CommandSQL.EXISTS.count("%s") == 2
+
+    def test_sp_receive_command_has_placeholders(self) -> None:
+        """SP_RECEIVE_COMMAND SQL should have 5 placeholders."""
+        assert CommandSQL.SP_RECEIVE_COMMAND.count("%s") == 5
+
+    def test_sp_finish_command_has_placeholders(self) -> None:
+        """SP_FINISH_COMMAND SQL should have 9 placeholders."""
+        assert CommandSQL.SP_FINISH_COMMAND.count("%s") == 9
+
+    def test_sp_fail_command_has_placeholders(self) -> None:
+        """SP_FAIL_COMMAND SQL should have 8 placeholders."""
+        assert CommandSQL.SP_FAIL_COMMAND.count("%s") == 8
+
+
+class TestCommandParams:
+    """Tests for CommandParams class."""
+
+    @pytest.fixture
+    def sample_metadata(self) -> CommandMetadata:
+        """Create sample CommandMetadata for testing."""
+        return CommandMetadata(
+            domain="test",
+            command_id=uuid4(),
+            command_type="TestCommand",
+            status=CommandStatus.PENDING,
+            attempts=0,
+            max_attempts=3,
+            msg_id=123,
+            correlation_id=uuid4(),
+            reply_to="reply_queue",
+            created_at=datetime(2024, 1, 1, 12, 0, 0),
+            updated_at=datetime(2024, 1, 1, 12, 0, 0),
+            batch_id=uuid4(),
+        )
+
+    def test_save_returns_correct_tuple_length(self, sample_metadata: CommandMetadata) -> None:
+        """save() should return 13 parameters."""
+        params = CommandParams.save(sample_metadata, "test__commands")
+        assert len(params) == 13
+
+    def test_save_returns_correct_values(self, sample_metadata: CommandMetadata) -> None:
+        """save() should return values in correct order."""
+        params = CommandParams.save(sample_metadata, "test__commands")
+
+        assert params[0] == sample_metadata.domain
+        assert params[1] == "test__commands"
+        assert params[2] == sample_metadata.msg_id
+        assert params[3] == sample_metadata.command_id
+        assert params[4] == sample_metadata.command_type
+        assert params[5] == sample_metadata.status.value
+        assert params[6] == sample_metadata.attempts
+        assert params[7] == sample_metadata.max_attempts
+        assert params[8] == sample_metadata.correlation_id
+        assert params[9] == sample_metadata.reply_to
+        assert params[10] == sample_metadata.created_at
+        assert params[11] == sample_metadata.updated_at
+        assert params[12] == sample_metadata.batch_id
+
+    def test_save_handles_none_reply_to(self, sample_metadata: CommandMetadata) -> None:
+        """save() should convert None reply_to to empty string."""
+        sample_metadata.reply_to = None
+        params = CommandParams.save(sample_metadata, "test__commands")
+        assert params[9] == ""
+
+    def test_update_status_returns_correct_tuple(self) -> None:
+        """update_status() should return 3 parameters."""
+        command_id = uuid4()
+        params = CommandParams.update_status(CommandStatus.COMPLETED, "test", command_id)
+
+        assert params == ("COMPLETED", "test", command_id)
+
+    def test_update_msg_id_returns_correct_tuple(self) -> None:
+        """update_msg_id() should return 3 parameters."""
+        command_id = uuid4()
+        params = CommandParams.update_msg_id(456, "test", command_id)
+
+        assert params == (456, "test", command_id)
+
+    def test_receive_command_returns_correct_tuple(self) -> None:
+        """receive_command() should return 3 parameters."""
+        command_id = uuid4()
+        params = CommandParams.receive_command(CommandStatus.IN_PROGRESS, "test", command_id)
+
+        assert params == ("IN_PROGRESS", "test", command_id)
+
+    def test_update_error_returns_correct_tuple(self) -> None:
+        """update_error() should return 5 parameters."""
+        command_id = uuid4()
+        params = CommandParams.update_error(
+            "TRANSIENT", "TIMEOUT", "Connection timed out", "test", command_id
+        )
+
+        assert params == ("TRANSIENT", "TIMEOUT", "Connection timed out", "test", command_id)
+
+    def test_finish_command_returns_correct_tuple(self) -> None:
+        """finish_command() should return 6 parameters."""
+        command_id = uuid4()
+        params = CommandParams.finish_command(
+            CommandStatus.COMPLETED, None, None, None, "test", command_id
+        )
+
+        assert params == ("COMPLETED", None, None, None, "test", command_id)
+
+    def test_finish_command_with_error(self) -> None:
+        """finish_command() should include error information."""
+        command_id = uuid4()
+        params = CommandParams.finish_command(
+            CommandStatus.FAILED, "PERMANENT", "INVALID_DATA", "Bad input", "test", command_id
+        )
+
+        assert params[0] == "FAILED"
+        assert params[1] == "PERMANENT"
+        assert params[2] == "INVALID_DATA"
+        assert params[3] == "Bad input"
+
+    def test_sp_receive_command_returns_correct_tuple(self) -> None:
+        """sp_receive_command() should return 5 parameters."""
+        command_id = uuid4()
+        params = CommandParams.sp_receive_command("test", command_id, "IN_PROGRESS", 123, 5)
+
+        assert params == ("test", command_id, "IN_PROGRESS", 123, 5)
+
+    def test_sp_receive_command_with_defaults(self) -> None:
+        """sp_receive_command() should use default values."""
+        command_id = uuid4()
+        params = CommandParams.sp_receive_command("test", command_id)
+
+        assert params == ("test", command_id, "IN_PROGRESS", None, None)
+
+    def test_sp_finish_command_returns_correct_tuple(self) -> None:
+        """sp_finish_command() should return 9 parameters."""
+        command_id = uuid4()
+        batch_id = uuid4()
+        params = CommandParams.sp_finish_command(
+            "test",
+            command_id,
+            CommandStatus.COMPLETED,
+            "COMPLETED",
+            None,
+            None,
+            None,
+            '{"key": "value"}',
+            batch_id,
+        )
+
+        assert len(params) == 9
+        assert params[0] == "test"
+        assert params[1] == command_id
+        assert params[2] == "COMPLETED"
+        assert params[3] == "COMPLETED"
+        assert params[7] == '{"key": "value"}'
+        assert params[8] == batch_id
+
+    def test_sp_fail_command_returns_correct_tuple(self) -> None:
+        """sp_fail_command() should return 8 parameters."""
+        command_id = uuid4()
+        params = CommandParams.sp_fail_command(
+            "test", command_id, "TRANSIENT", "TIMEOUT", "Timed out", 2, 3, 456
+        )
+
+        assert len(params) == 8
+        assert params[0] == "test"
+        assert params[1] == command_id
+        assert params[2] == "TRANSIENT"
+        assert params[3] == "TIMEOUT"
+        assert params[4] == "Timed out"
+        assert params[5] == 2
+        assert params[6] == 3
+        assert params[7] == 456
+
+
+class TestCommandParsers:
+    """Tests for CommandParsers class."""
+
+    def test_from_row_creates_metadata(self) -> None:
+        """from_row() should create CommandMetadata from tuple."""
+        command_id = uuid4()
+        correlation_id = uuid4()
+        batch_id = uuid4()
+        created_at = datetime(2024, 1, 1, 12, 0, 0)
+        updated_at = datetime(2024, 1, 1, 12, 1, 0)
+
+        row = (
+            "test",  # domain
+            command_id,  # command_id
+            "TestCommand",  # command_type
+            "PENDING",  # status
+            0,  # attempts
+            3,  # max_attempts
+            123,  # msg_id
+            correlation_id,  # correlation_id
+            "reply_queue",  # reply_queue
+            None,  # last_error_type
+            None,  # last_error_code
+            None,  # last_error_msg
+            created_at,  # created_at
+            updated_at,  # updated_at
+            batch_id,  # batch_id
+        )
+
+        metadata = CommandParsers.from_row(row)
+
+        assert metadata.domain == "test"
+        assert metadata.command_id == command_id
+        assert metadata.command_type == "TestCommand"
+        assert metadata.status == CommandStatus.PENDING
+        assert metadata.attempts == 0
+        assert metadata.max_attempts == 3
+        assert metadata.msg_id == 123
+        assert metadata.correlation_id == correlation_id
+        assert metadata.reply_to == "reply_queue"
+        assert metadata.last_error_type is None
+        assert metadata.last_error_code is None
+        assert metadata.last_error_msg is None
+        assert metadata.created_at == created_at
+        assert metadata.updated_at == updated_at
+        assert metadata.batch_id == batch_id
+
+    def test_from_row_handles_empty_reply_to(self) -> None:
+        """from_row() should convert empty string reply_to to None."""
+        row = (
+            "test",
+            uuid4(),
+            "TestCommand",
+            "PENDING",
+            0,
+            3,
+            123,
+            None,
+            "",  # empty reply_queue
+            None,
+            None,
+            None,
+            datetime.now(),
+            datetime.now(),
+            None,
+        )
+
+        metadata = CommandParsers.from_row(row)
+        assert metadata.reply_to is None
+
+    def test_from_row_preserves_error_info(self) -> None:
+        """from_row() should preserve error information."""
+        row = (
+            "test",
+            uuid4(),
+            "TestCommand",
+            "FAILED",
+            3,
+            3,
+            123,
+            None,
+            None,
+            "TRANSIENT",  # last_error_type
+            "TIMEOUT",  # last_error_code
+            "Connection timed out",  # last_error_msg
+            datetime.now(),
+            datetime.now(),
+            None,
+        )
+
+        metadata = CommandParsers.from_row(row)
+
+        assert metadata.last_error_type == "TRANSIENT"
+        assert metadata.last_error_code == "TIMEOUT"
+        assert metadata.last_error_msg == "Connection timed out"
+
+    def test_from_row_handles_all_statuses(self) -> None:
+        """from_row() should handle all CommandStatus values."""
+        for status in CommandStatus:
+            row = (
+                "test",
+                uuid4(),
+                "TestCommand",
+                status.value,
+                0,
+                3,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                datetime.now(),
+                datetime.now(),
+                None,
+            )
+
+            metadata = CommandParsers.from_row(row)
+            assert metadata.status == status
+
+    def test_from_rows_creates_list(self) -> None:
+        """from_rows() should create list of CommandMetadata."""
+        rows = [
+            (
+                "test",
+                uuid4(),
+                "TestCommand1",
+                "PENDING",
+                0,
+                3,
+                1,
+                None,
+                None,
+                None,
+                None,
+                None,
+                datetime.now(),
+                datetime.now(),
+                None,
+            ),
+            (
+                "test",
+                uuid4(),
+                "TestCommand2",
+                "COMPLETED",
+                1,
+                3,
+                2,
+                None,
+                None,
+                None,
+                None,
+                None,
+                datetime.now(),
+                datetime.now(),
+                None,
+            ),
+        ]
+
+        metadata_list = CommandParsers.from_rows(rows)
+
+        assert len(metadata_list) == 2
+        assert metadata_list[0].command_type == "TestCommand1"
+        assert metadata_list[1].command_type == "TestCommand2"
+
+    def test_from_rows_handles_empty_list(self) -> None:
+        """from_rows() should handle empty list."""
+        metadata_list = CommandParsers.from_rows([])
+        assert metadata_list == []

--- a/tests/unit/core/test_core_init.py
+++ b/tests/unit/core/test_core_init.py
@@ -1,0 +1,62 @@
+"""Unit tests for commandbus._core module initialization."""
+
+from commandbus._core import (
+    BatchParams,
+    BatchParsers,
+    BatchSQL,
+    CommandParams,
+    CommandParsers,
+    CommandSQL,
+    PgmqParams,
+    PgmqParsers,
+    PgmqSQL,
+)
+
+
+class TestCoreModuleExports:
+    """Tests for _core module exports."""
+
+    def test_command_sql_exported(self) -> None:
+        """CommandSQL should be exported from _core."""
+        assert CommandSQL is not None
+        assert hasattr(CommandSQL, "SAVE")
+
+    def test_command_params_exported(self) -> None:
+        """CommandParams should be exported from _core."""
+        assert CommandParams is not None
+        assert hasattr(CommandParams, "save")
+
+    def test_command_parsers_exported(self) -> None:
+        """CommandParsers should be exported from _core."""
+        assert CommandParsers is not None
+        assert hasattr(CommandParsers, "from_row")
+
+    def test_batch_sql_exported(self) -> None:
+        """BatchSQL should be exported from _core."""
+        assert BatchSQL is not None
+        assert hasattr(BatchSQL, "SAVE")
+
+    def test_batch_params_exported(self) -> None:
+        """BatchParams should be exported from _core."""
+        assert BatchParams is not None
+        assert hasattr(BatchParams, "save")
+
+    def test_batch_parsers_exported(self) -> None:
+        """BatchParsers should be exported from _core."""
+        assert BatchParsers is not None
+        assert hasattr(BatchParsers, "from_row")
+
+    def test_pgmq_sql_exported(self) -> None:
+        """PgmqSQL should be exported from _core."""
+        assert PgmqSQL is not None
+        assert hasattr(PgmqSQL, "SEND")
+
+    def test_pgmq_params_exported(self) -> None:
+        """PgmqParams should be exported from _core."""
+        assert PgmqParams is not None
+        assert hasattr(PgmqParams, "send")
+
+    def test_pgmq_parsers_exported(self) -> None:
+        """PgmqParsers should be exported from _core."""
+        assert PgmqParsers is not None
+        assert hasattr(PgmqParsers, "from_row")

--- a/tests/unit/core/test_pgmq_sql.py
+++ b/tests/unit/core/test_pgmq_sql.py
@@ -1,0 +1,238 @@
+"""Unit tests for commandbus._core.pgmq_sql module."""
+
+import json
+from datetime import datetime
+
+from commandbus._core.pgmq_sql import (
+    PGMQ_NOTIFY_CHANNEL,
+    PgmqMessage,
+    PgmqParams,
+    PgmqParsers,
+    PgmqSQL,
+)
+
+
+class TestPgmqMessage:
+    """Tests for PgmqMessage dataclass."""
+
+    def test_pgmq_message_creation(self) -> None:
+        """PgmqMessage should store all fields correctly."""
+        msg = PgmqMessage(
+            msg_id=123,
+            read_count=1,
+            enqueued_at="2024-01-01T12:00:00",
+            vt="2024-01-01T12:00:30",
+            message={"command_id": "abc", "data": {"key": "value"}},
+        )
+
+        assert msg.msg_id == 123
+        assert msg.read_count == 1
+        assert msg.enqueued_at == "2024-01-01T12:00:00"
+        assert msg.vt == "2024-01-01T12:00:30"
+        assert msg.message == {"command_id": "abc", "data": {"key": "value"}}
+
+
+class TestPgmqSQL:
+    """Tests for PgmqSQL class."""
+
+    def test_create_queue_has_placeholder(self) -> None:
+        """CREATE_QUEUE SQL should have 1 placeholder."""
+        assert PgmqSQL.CREATE_QUEUE.count("%s") == 1
+
+    def test_send_has_placeholders(self) -> None:
+        """SEND SQL should have 3 placeholders."""
+        assert PgmqSQL.SEND.count("%s") == 3
+
+    def test_send_batch_has_placeholders(self) -> None:
+        """SEND_BATCH SQL should have 3 placeholders."""
+        assert PgmqSQL.SEND_BATCH.count("%s") == 3
+
+    def test_read_has_placeholders(self) -> None:
+        """READ SQL should have 3 placeholders."""
+        assert PgmqSQL.READ.count("%s") == 3
+
+    def test_delete_has_placeholders(self) -> None:
+        """DELETE SQL should have 2 placeholders."""
+        assert PgmqSQL.DELETE.count("%s") == 2
+
+    def test_archive_has_placeholders(self) -> None:
+        """ARCHIVE SQL should have 2 placeholders."""
+        assert PgmqSQL.ARCHIVE.count("%s") == 2
+
+    def test_set_vt_has_placeholders(self) -> None:
+        """SET_VT SQL should have 3 placeholders."""
+        assert PgmqSQL.SET_VT.count("%s") == 3
+
+    def test_notify_channel_returns_formatted_name(self) -> None:
+        """notify_channel() should return correctly formatted channel name."""
+        channel = PgmqSQL.notify_channel("test__commands")
+        assert channel == "pgmq_notify_test__commands"
+
+    def test_notify_channel_uses_constant(self) -> None:
+        """notify_channel() should use PGMQ_NOTIFY_CHANNEL constant."""
+        channel = PgmqSQL.notify_channel("myqueue")
+        assert channel.startswith(PGMQ_NOTIFY_CHANNEL)
+
+    def test_notify_sql_returns_sql_statement(self) -> None:
+        """notify_sql() should return NOTIFY SQL statement."""
+        sql = PgmqSQL.notify_sql("test__commands")
+        assert sql == "NOTIFY pgmq_notify_test__commands"
+
+    def test_notify_sql_with_different_queue(self) -> None:
+        """notify_sql() should work with various queue names."""
+        sql = PgmqSQL.notify_sql("payments__commands")
+        assert sql == "NOTIFY pgmq_notify_payments__commands"
+
+
+class TestPgmqParams:
+    """Tests for PgmqParams class."""
+
+    def test_create_queue_returns_tuple(self) -> None:
+        """create_queue() should return 1-element tuple."""
+        params = PgmqParams.create_queue("test__commands")
+        assert params == ("test__commands",)
+
+    def test_send_returns_tuple_with_json(self) -> None:
+        """send() should return tuple with JSON-serialized message."""
+        message = {"command_id": "abc", "data": {"key": "value"}}
+        params = PgmqParams.send("test__commands", message, delay=5)
+
+        assert params[0] == "test__commands"
+        assert params[1] == json.dumps(message)
+        assert params[2] == 5
+
+    def test_send_default_delay(self) -> None:
+        """send() should default delay to 0."""
+        params = PgmqParams.send("test__commands", {"key": "value"})
+        assert params[2] == 0
+
+    def test_send_batch_returns_tuple_with_json_list(self) -> None:
+        """send_batch() should return tuple with JSON-serialized messages list."""
+        messages = [{"id": 1}, {"id": 2}, {"id": 3}]
+        params = PgmqParams.send_batch("test__commands", messages, delay=10)
+
+        assert params[0] == "test__commands"
+        assert params[1] == [json.dumps(m) for m in messages]
+        assert params[2] == 10
+
+    def test_send_batch_empty_list(self) -> None:
+        """send_batch() should handle empty message list."""
+        params = PgmqParams.send_batch("test__commands", [])
+        assert params[1] == []
+
+    def test_read_returns_tuple(self) -> None:
+        """read() should return 3-element tuple."""
+        params = PgmqParams.read("test__commands", visibility_timeout=60, batch_size=10)
+
+        assert params == ("test__commands", 60, 10)
+
+    def test_read_default_values(self) -> None:
+        """read() should use default values."""
+        params = PgmqParams.read("test__commands")
+        assert params == ("test__commands", 30, 1)
+
+    def test_delete_returns_tuple(self) -> None:
+        """delete() should return 2-element tuple."""
+        params = PgmqParams.delete("test__commands", 123)
+        assert params == ("test__commands", 123)
+
+    def test_archive_returns_tuple(self) -> None:
+        """archive() should return 2-element tuple."""
+        params = PgmqParams.archive("test__commands", 456)
+        assert params == ("test__commands", 456)
+
+    def test_set_vt_returns_tuple(self) -> None:
+        """set_vt() should return 3-element tuple."""
+        params = PgmqParams.set_vt("test__commands", 789, 90)
+        assert params == ("test__commands", 789, 90)
+
+
+class TestPgmqParsers:
+    """Tests for PgmqParsers class."""
+
+    def test_from_row_creates_message(self) -> None:
+        """from_row() should create PgmqMessage from tuple."""
+        row = (
+            123,  # msg_id
+            1,  # read_ct
+            "2024-01-01T12:00:00+00:00",  # enqueued_at
+            "2024-01-01T12:00:30+00:00",  # vt
+            {"command_id": "abc", "data": {"key": "value"}},  # message (dict)
+        )
+
+        msg = PgmqParsers.from_row(row)
+
+        assert msg.msg_id == 123
+        assert msg.read_count == 1
+        assert msg.enqueued_at == "2024-01-01T12:00:00+00:00"
+        assert msg.vt == "2024-01-01T12:00:30+00:00"
+        assert msg.message == {"command_id": "abc", "data": {"key": "value"}}
+
+    def test_from_row_parses_json_string_message(self) -> None:
+        """from_row() should parse JSON string message."""
+        row = (
+            456,
+            2,
+            "2024-01-01T12:00:00",
+            "2024-01-01T12:00:30",
+            '{"command_id": "xyz", "data": {"nested": true}}',  # JSON string
+        )
+
+        msg = PgmqParsers.from_row(row)
+
+        assert msg.message == {"command_id": "xyz", "data": {"nested": True}}
+
+    def test_from_row_converts_timestamps_to_string(self) -> None:
+        """from_row() should convert timestamps to strings."""
+        row = (
+            789,
+            0,
+            datetime(2024, 1, 1, 12, 0, 0),  # datetime object
+            datetime(2024, 1, 1, 12, 0, 30),  # datetime object
+            {"key": "value"},
+        )
+
+        msg = PgmqParsers.from_row(row)
+
+        assert isinstance(msg.enqueued_at, str)
+        assert isinstance(msg.vt, str)
+
+    def test_from_rows_creates_list(self) -> None:
+        """from_rows() should create list of PgmqMessage."""
+        rows = [
+            (1, 0, "2024-01-01T12:00:00", "2024-01-01T12:00:30", {"id": 1}),
+            (2, 1, "2024-01-01T12:01:00", "2024-01-01T12:01:30", {"id": 2}),
+            (3, 0, "2024-01-01T12:02:00", "2024-01-01T12:02:30", {"id": 3}),
+        ]
+
+        messages = PgmqParsers.from_rows(rows)
+
+        assert len(messages) == 3
+        assert messages[0].msg_id == 1
+        assert messages[1].msg_id == 2
+        assert messages[2].msg_id == 3
+
+    def test_from_rows_handles_empty_list(self) -> None:
+        """from_rows() should handle empty list."""
+        messages = PgmqParsers.from_rows([])
+        assert messages == []
+
+    def test_from_rows_with_mixed_message_formats(self) -> None:
+        """from_rows() should handle both dict and string messages."""
+        rows = [
+            (1, 0, "2024-01-01T12:00:00", "2024-01-01T12:00:30", {"id": 1}),
+            (2, 1, "2024-01-01T12:01:00", "2024-01-01T12:01:30", '{"id": 2}'),
+        ]
+
+        messages = PgmqParsers.from_rows(rows)
+
+        assert messages[0].message == {"id": 1}
+        assert messages[1].message == {"id": 2}
+
+
+class TestPgmqNotifyChannel:
+    """Tests for PGMQ_NOTIFY_CHANNEL constant."""
+
+    def test_notify_channel_constant_value(self) -> None:
+        """PGMQ_NOTIFY_CHANNEL should have expected value."""
+        assert PGMQ_NOTIFY_CHANNEL == "pgmq_notify"


### PR DESCRIPTION
## Summary

- Create `_core/` module with SQL constants, parameter builders, and row parsers
- Extract shared logic from async repositories for use by both async and sync implementations
- Add `CommandSQL`, `CommandParams`, `CommandParsers` for command operations
- Add `BatchSQL`, `BatchParams`, `BatchParsers` for batch operations
- Add `PgmqSQL`, `PgmqParams`, `PgmqParsers` for PGMQ operations

## Test plan

- [x] Unit tests pass with 100% coverage on `_core/` module
- [x] `make ready` passes all checks
- [x] All 91 unit tests for the new module pass

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)