### PR TITLE
feat: Add native sync process repository (S079)

### DIFF
--- a/src/commandbus/_core/__init__.py
+++ b/src/commandbus/_core/__init__.py
@@ -7,6 +7,7 @@ that are shared between async and sync repository implementations.
 from commandbus._core.batch_sql import BatchParams, BatchParsers, BatchSQL
 from commandbus._core.command_sql import CommandParams, CommandParsers, CommandSQL
 from commandbus._core.pgmq_sql import PgmqParams, PgmqParsers, PgmqSQL
+from commandbus._core.process_sql import ProcessParams, ProcessParsers, ProcessSQL
 
 __all__ = [
     "BatchParams",
@@ -18,4 +19,7 @@ __all__ = [
     "PgmqParams",
     "PgmqParsers",
     "PgmqSQL",
+    "ProcessParams",
+    "ProcessParsers",
+    "ProcessSQL",
 ]

--- a/src/commandbus/_core/process_sql.py
+++ b/src/commandbus/_core/process_sql.py
@@ -1,0 +1,291 @@
+"""SQL constants, parameter builders, and row parsers for process operations.
+
+This module extracts shared SQL logic for both async and sync implementations.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from commandbus.models import ReplyOutcome
+from commandbus.process.models import (
+    ProcessAuditEntry,
+    ProcessMetadata,
+    ProcessStatus,
+)
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+
+class ProcessSQL:
+    """SQL constants for process operations."""
+
+    # Column order for SELECT queries
+    SELECT_COLUMNS = """
+        domain, process_id, process_type, status, current_step,
+        state, error_code, error_message,
+        created_at, updated_at, completed_at
+    """
+
+    SAVE = """
+        INSERT INTO commandbus.process (
+            domain, process_id, process_type, status, current_step,
+            state, error_code, error_message,
+            created_at, updated_at, completed_at
+        ) VALUES (
+            %s, %s, %s, %s, %s,
+            %s, %s, %s,
+            %s, %s, %s
+        )
+    """
+
+    UPDATE = """
+        UPDATE commandbus.process SET
+            status = %s,
+            current_step = %s,
+            state = %s,
+            error_code = %s,
+            error_message = %s,
+            updated_at = NOW(),
+            completed_at = %s
+        WHERE domain = %s AND process_id = %s
+    """
+
+    GET_BY_ID = f"""
+        SELECT {SELECT_COLUMNS}
+        FROM commandbus.process
+        WHERE domain = %s AND process_id = %s
+    """
+
+    FIND_BY_STATUS = f"""
+        SELECT {SELECT_COLUMNS}
+        FROM commandbus.process
+        WHERE domain = %s AND status = ANY(%s)
+    """
+
+    # Audit table queries
+    LOG_STEP = """
+        INSERT INTO commandbus.process_audit (
+            domain, process_id, step_name, command_id, command_type,
+            command_data, sent_at, reply_outcome, reply_data, received_at
+        ) VALUES (
+            %s, %s, %s, %s, %s,
+            %s, %s, %s, %s, %s
+        )
+    """
+
+    UPDATE_STEP_REPLY = """
+        UPDATE commandbus.process_audit SET
+            reply_outcome = %s,
+            reply_data = %s,
+            received_at = %s
+        WHERE domain = %s AND process_id = %s AND command_id = %s
+    """
+
+    GET_AUDIT_TRAIL = """
+        SELECT step_name, command_id, command_type, command_data,
+               sent_at, reply_outcome, reply_data, received_at
+        FROM commandbus.process_audit
+        WHERE domain = %s AND process_id = %s
+        ORDER BY sent_at ASC
+    """
+
+    GET_COMPLETED_STEPS = """
+        SELECT step_name
+        FROM commandbus.process_audit
+        WHERE domain = %s AND process_id = %s AND reply_outcome = 'SUCCESS'
+        ORDER BY sent_at ASC
+    """
+
+
+class ProcessParams:
+    """Static methods for building SQL parameter tuples."""
+
+    @staticmethod
+    def save(process: ProcessMetadata[Any, Any], state_data: dict[str, Any]) -> tuple[Any, ...]:
+        """Build parameters for SAVE query.
+
+        Args:
+            process: Process metadata to save
+            state_data: Serialized state data (dict form)
+
+        Returns:
+            Tuple of 11 parameters for SAVE SQL
+        """
+        return (
+            process.domain,
+            process.process_id,
+            process.process_type,
+            process.status.value,
+            process.current_step,
+            json.dumps(state_data),
+            process.error_code,
+            process.error_message,
+            process.created_at,
+            process.updated_at,
+            process.completed_at,
+        )
+
+    @staticmethod
+    def update(process: ProcessMetadata[Any, Any], state_data: dict[str, Any]) -> tuple[Any, ...]:
+        """Build parameters for UPDATE query.
+
+        Args:
+            process: Process metadata to update
+            state_data: Serialized state data (dict form)
+
+        Returns:
+            Tuple of 8 parameters for UPDATE SQL
+        """
+        return (
+            process.status.value,
+            process.current_step,
+            json.dumps(state_data),
+            process.error_code,
+            process.error_message,
+            process.completed_at,
+            process.domain,
+            process.process_id,
+        )
+
+    @staticmethod
+    def get_by_id(domain: str, process_id: UUID) -> tuple[str, UUID]:
+        """Build parameters for GET_BY_ID query."""
+        return (domain, process_id)
+
+    @staticmethod
+    def find_by_status(domain: str, statuses: list[ProcessStatus]) -> tuple[str, list[str]]:
+        """Build parameters for FIND_BY_STATUS query."""
+        status_values = [s.value for s in statuses]
+        return (domain, status_values)
+
+    @staticmethod
+    def log_step(domain: str, process_id: UUID, entry: ProcessAuditEntry) -> tuple[Any, ...]:
+        """Build parameters for LOG_STEP query.
+
+        Args:
+            domain: The domain
+            process_id: The process ID
+            entry: Audit entry to log
+
+        Returns:
+            Tuple of 10 parameters for LOG_STEP SQL
+        """
+        return (
+            domain,
+            process_id,
+            entry.step_name,
+            entry.command_id,
+            entry.command_type,
+            json.dumps(entry.command_data) if entry.command_data is not None else None,
+            entry.sent_at,
+            entry.reply_outcome.value if entry.reply_outcome else None,
+            json.dumps(entry.reply_data) if entry.reply_data is not None else None,
+            entry.received_at,
+        )
+
+    @staticmethod
+    def update_step_reply(
+        domain: str, process_id: UUID, command_id: UUID, entry: ProcessAuditEntry
+    ) -> tuple[Any, ...]:
+        """Build parameters for UPDATE_STEP_REPLY query."""
+        return (
+            entry.reply_outcome.value if entry.reply_outcome else None,
+            json.dumps(entry.reply_data) if entry.reply_data is not None else None,
+            entry.received_at,
+            domain,
+            process_id,
+            command_id,
+        )
+
+    @staticmethod
+    def get_audit_trail(domain: str, process_id: UUID) -> tuple[str, UUID]:
+        """Build parameters for GET_AUDIT_TRAIL query."""
+        return (domain, process_id)
+
+    @staticmethod
+    def get_completed_steps(domain: str, process_id: UUID) -> tuple[str, UUID]:
+        """Build parameters for GET_COMPLETED_STEPS query."""
+        return (domain, process_id)
+
+
+class ProcessParsers:
+    """Static methods for parsing database rows."""
+
+    @staticmethod
+    def from_row(row: tuple[Any, ...]) -> ProcessMetadata[Any, Any]:
+        """Parse a database row to ProcessMetadata.
+
+        Expected column order (11 fields):
+            domain, process_id, process_type, status, current_step,
+            state, error_code, error_message,
+            created_at, updated_at, completed_at
+
+        Args:
+            row: Database row tuple
+
+        Returns:
+            ProcessMetadata instance
+        """
+        state = row[5]
+        if isinstance(state, str):
+            state = json.loads(state)
+
+        return ProcessMetadata(
+            domain=row[0],
+            process_id=row[1],
+            process_type=row[2],
+            status=ProcessStatus(row[3]),
+            current_step=row[4],
+            state=state,
+            error_code=row[6],
+            error_message=row[7],
+            created_at=row[8],
+            updated_at=row[9],
+            completed_at=row[10],
+        )
+
+    @staticmethod
+    def from_rows(rows: list[tuple[Any, ...]]) -> list[ProcessMetadata[Any, Any]]:
+        """Parse multiple database rows to ProcessMetadata list."""
+        return [ProcessParsers.from_row(row) for row in rows]
+
+    @staticmethod
+    def audit_entry_from_row(row: tuple[Any, ...]) -> ProcessAuditEntry:
+        """Parse a database row to ProcessAuditEntry.
+
+        Expected column order (8 fields):
+            step_name, command_id, command_type, command_data,
+            sent_at, reply_outcome, reply_data, received_at
+
+        Args:
+            row: Database row tuple
+
+        Returns:
+            ProcessAuditEntry instance
+        """
+        command_data = row[3]
+        if isinstance(command_data, str):
+            command_data = json.loads(command_data)
+
+        reply_data = row[6]
+        if isinstance(reply_data, str):
+            reply_data = json.loads(reply_data)
+
+        return ProcessAuditEntry(
+            step_name=row[0],
+            command_id=row[1],
+            command_type=row[2],
+            command_data=command_data,
+            sent_at=row[4],
+            reply_outcome=ReplyOutcome(row[5]) if row[5] else None,
+            reply_data=reply_data,
+            received_at=row[7],
+        )
+
+    @staticmethod
+    def audit_entries_from_rows(rows: list[tuple[Any, ...]]) -> list[ProcessAuditEntry]:
+        """Parse multiple database rows to ProcessAuditEntry list."""
+        return [ProcessParsers.audit_entry_from_row(row) for row in rows]

--- a/src/commandbus/sync/repositories/__init__.py
+++ b/src/commandbus/sync/repositories/__init__.py
@@ -1,0 +1,7 @@
+"""Synchronous repository implementations."""
+
+from commandbus.sync.repositories.process import SyncProcessRepository
+
+__all__ = [
+    "SyncProcessRepository",
+]

--- a/src/commandbus/sync/repositories/process.py
+++ b/src/commandbus/sync/repositories/process.py
@@ -1,0 +1,323 @@
+"""Native synchronous process repository.
+
+This module provides a synchronous process repository using psycopg3's
+thread-safe ConnectionPool for native sync operations without
+async wrapper overhead.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from commandbus._core.process_sql import ProcessParams, ProcessParsers, ProcessSQL
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from psycopg import Connection
+    from psycopg_pool import ConnectionPool
+
+    from commandbus.process.models import (
+        ProcessAuditEntry,
+        ProcessMetadata,
+        ProcessStatus,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class SyncProcessRepository:
+    """Synchronous process repository using native sync connections.
+
+    This repository provides sync methods for process metadata persistence,
+    using psycopg3's thread-safe ConnectionPool. Each method accepts an
+    optional connection parameter for transaction support.
+
+    Example:
+        pool = ConnectionPool(conninfo=DATABASE_URL)
+        repo = SyncProcessRepository(pool)
+
+        # Save a process
+        repo.save(process)
+
+        # Get process by ID
+        process = repo.get_by_id(domain, process_id)
+
+        # Log a step
+        repo.log_step(domain, process_id, entry)
+    """
+
+    def __init__(self, pool: ConnectionPool[Any]) -> None:
+        """Initialize the sync process repository.
+
+        Args:
+            pool: psycopg sync connection pool
+        """
+        self._pool = pool
+
+    def save(
+        self,
+        process: ProcessMetadata[Any, Any],
+        conn: Connection[Any] | None = None,
+    ) -> None:
+        """Save a new process to the database.
+
+        Args:
+            process: Process metadata to save
+            conn: Optional connection (for transaction support)
+        """
+        state_data = process.state
+        if hasattr(state_data, "to_dict"):
+            state_data = state_data.to_dict()
+
+        sql = ProcessSQL.SAVE
+        params = ProcessParams.save(process, state_data)
+
+        if conn is not None:
+            conn.execute(sql, params)
+        else:
+            with self._pool.connection() as c:
+                c.execute(sql, params)
+
+        logger.debug("Saved process: %s.%s", process.domain, process.process_id)
+
+    def update(
+        self,
+        process: ProcessMetadata[Any, Any],
+        conn: Connection[Any] | None = None,
+    ) -> None:
+        """Update an existing process.
+
+        Args:
+            process: Process metadata to update
+            conn: Optional connection (for transaction support)
+        """
+        state_data = process.state
+        if hasattr(state_data, "to_dict"):
+            state_data = state_data.to_dict()
+
+        sql = ProcessSQL.UPDATE
+        params = ProcessParams.update(process, state_data)
+
+        if conn is not None:
+            conn.execute(sql, params)
+        else:
+            with self._pool.connection() as c:
+                c.execute(sql, params)
+
+        logger.debug("Updated process: %s.%s", process.domain, process.process_id)
+
+    def get_by_id(
+        self,
+        domain: str,
+        process_id: UUID,
+        conn: Connection[Any] | None = None,
+    ) -> ProcessMetadata[Any, Any] | None:
+        """Get process by domain and process_id.
+
+        Args:
+            domain: The domain
+            process_id: The process ID
+            conn: Optional connection (for transaction support)
+
+        Returns:
+            ProcessMetadata if found, None otherwise
+        """
+        sql = ProcessSQL.GET_BY_ID
+        params = ProcessParams.get_by_id(domain, process_id)
+
+        if conn is not None:
+            return self._get_by_id_with_conn(conn, sql, params)
+        else:
+            with self._pool.connection() as c:
+                return self._get_by_id_with_conn(c, sql, params)
+
+    def _get_by_id_with_conn(
+        self,
+        conn: Connection[Any],
+        sql: str,
+        params: tuple[str, UUID],
+    ) -> ProcessMetadata[Any, Any] | None:
+        """Get process using an existing connection."""
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+            row = cur.fetchone()
+
+        if row is None:
+            return None
+
+        return ProcessParsers.from_row(row)
+
+    def find_by_status(
+        self,
+        domain: str,
+        statuses: list[ProcessStatus],
+        conn: Connection[Any] | None = None,
+    ) -> list[ProcessMetadata[Any, Any]]:
+        """Find processes by status.
+
+        Args:
+            domain: The domain
+            statuses: List of statuses to filter by
+            conn: Optional connection (for transaction support)
+
+        Returns:
+            List of ProcessMetadata matching the statuses
+        """
+        sql = ProcessSQL.FIND_BY_STATUS
+        params = ProcessParams.find_by_status(domain, statuses)
+
+        if conn is not None:
+            return self._find_by_status_with_conn(conn, sql, params)
+        else:
+            with self._pool.connection() as c:
+                return self._find_by_status_with_conn(c, sql, params)
+
+    def _find_by_status_with_conn(
+        self,
+        conn: Connection[Any],
+        sql: str,
+        params: tuple[str, list[str]],
+    ) -> list[ProcessMetadata[Any, Any]]:
+        """Find processes using an existing connection."""
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+
+        return ProcessParsers.from_rows(rows)
+
+    def log_step(
+        self,
+        domain: str,
+        process_id: UUID,
+        entry: ProcessAuditEntry,
+        conn: Connection[Any] | None = None,
+    ) -> None:
+        """Log a step execution to audit trail.
+
+        Args:
+            domain: The domain
+            process_id: The process ID
+            entry: Audit entry to log
+            conn: Optional connection (for transaction support)
+        """
+        sql = ProcessSQL.LOG_STEP
+        params = ProcessParams.log_step(domain, process_id, entry)
+
+        if conn is not None:
+            conn.execute(sql, params)
+        else:
+            with self._pool.connection() as c:
+                c.execute(sql, params)
+
+        logger.debug("Logged step %s for process %s.%s", entry.step_name, domain, process_id)
+
+    def update_step_reply(
+        self,
+        domain: str,
+        process_id: UUID,
+        command_id: UUID,
+        entry: ProcessAuditEntry,
+        conn: Connection[Any] | None = None,
+    ) -> None:
+        """Update step with reply information.
+
+        Args:
+            domain: The domain
+            process_id: The process ID
+            command_id: The command ID of the step
+            entry: Audit entry with reply data
+            conn: Optional connection (for transaction support)
+        """
+        sql = ProcessSQL.UPDATE_STEP_REPLY
+        params = ProcessParams.update_step_reply(domain, process_id, command_id, entry)
+
+        if conn is not None:
+            conn.execute(sql, params)
+        else:
+            with self._pool.connection() as c:
+                c.execute(sql, params)
+
+        logger.debug(
+            "Updated step reply for command %s in process %s.%s",
+            command_id,
+            domain,
+            process_id,
+        )
+
+    def get_audit_trail(
+        self,
+        domain: str,
+        process_id: UUID,
+        conn: Connection[Any] | None = None,
+    ) -> list[ProcessAuditEntry]:
+        """Get full audit trail for a process.
+
+        Args:
+            domain: The domain
+            process_id: The process ID
+            conn: Optional connection (for transaction support)
+
+        Returns:
+            List of ProcessAuditEntry ordered by sent_at ascending
+        """
+        sql = ProcessSQL.GET_AUDIT_TRAIL
+        params = ProcessParams.get_audit_trail(domain, process_id)
+
+        if conn is not None:
+            return self._get_audit_trail_with_conn(conn, sql, params)
+        else:
+            with self._pool.connection() as c:
+                return self._get_audit_trail_with_conn(c, sql, params)
+
+    def _get_audit_trail_with_conn(
+        self,
+        conn: Connection[Any],
+        sql: str,
+        params: tuple[str, UUID],
+    ) -> list[ProcessAuditEntry]:
+        """Get audit trail using an existing connection."""
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+
+        return ProcessParsers.audit_entries_from_rows(rows)
+
+    def get_completed_steps(
+        self,
+        domain: str,
+        process_id: UUID,
+        conn: Connection[Any] | None = None,
+    ) -> list[str]:
+        """Get list of completed step names (for compensation).
+
+        Args:
+            domain: The domain
+            process_id: The process ID
+            conn: Optional connection (for transaction support)
+
+        Returns:
+            List of step names that completed successfully
+        """
+        sql = ProcessSQL.GET_COMPLETED_STEPS
+        params = ProcessParams.get_completed_steps(domain, process_id)
+
+        if conn is not None:
+            return self._get_completed_steps_with_conn(conn, sql, params)
+        else:
+            with self._pool.connection() as c:
+                return self._get_completed_steps_with_conn(c, sql, params)
+
+    def _get_completed_steps_with_conn(
+        self,
+        conn: Connection[Any],
+        sql: str,
+        params: tuple[str, UUID],
+    ) -> list[str]:
+        """Get completed steps using an existing connection."""
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+
+        return [row[0] for row in rows]

--- a/tests/unit/core/test_process_sql.py
+++ b/tests/unit/core/test_process_sql.py
@@ -1,0 +1,351 @@
+"""Unit tests for commandbus._core.process_sql module."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from commandbus._core.process_sql import ProcessParams, ProcessParsers, ProcessSQL
+from commandbus.models import ReplyOutcome
+from commandbus.process.models import (
+    ProcessAuditEntry,
+    ProcessMetadata,
+    ProcessStatus,
+)
+
+
+class TestProcessSQL:
+    """Tests for ProcessSQL constants."""
+
+    def test_select_columns_defined(self) -> None:
+        """SELECT_COLUMNS should be defined."""
+        assert ProcessSQL.SELECT_COLUMNS is not None
+        assert "domain" in ProcessSQL.SELECT_COLUMNS
+        assert "process_id" in ProcessSQL.SELECT_COLUMNS
+
+    def test_save_defined(self) -> None:
+        """SAVE SQL should be defined."""
+        assert ProcessSQL.SAVE is not None
+        assert "INSERT INTO" in ProcessSQL.SAVE
+        assert "commandbus.process" in ProcessSQL.SAVE
+
+    def test_update_defined(self) -> None:
+        """UPDATE SQL should be defined."""
+        assert ProcessSQL.UPDATE is not None
+        assert "UPDATE" in ProcessSQL.UPDATE
+        assert "NOW()" in ProcessSQL.UPDATE
+
+    def test_get_by_id_defined(self) -> None:
+        """GET_BY_ID SQL should be defined."""
+        assert ProcessSQL.GET_BY_ID is not None
+        assert "SELECT" in ProcessSQL.GET_BY_ID
+
+    def test_find_by_status_defined(self) -> None:
+        """FIND_BY_STATUS SQL should be defined."""
+        assert ProcessSQL.FIND_BY_STATUS is not None
+        assert "ANY" in ProcessSQL.FIND_BY_STATUS
+
+    def test_log_step_defined(self) -> None:
+        """LOG_STEP SQL should be defined."""
+        assert ProcessSQL.LOG_STEP is not None
+        assert "INSERT INTO" in ProcessSQL.LOG_STEP
+        assert "process_audit" in ProcessSQL.LOG_STEP
+
+    def test_update_step_reply_defined(self) -> None:
+        """UPDATE_STEP_REPLY SQL should be defined."""
+        assert ProcessSQL.UPDATE_STEP_REPLY is not None
+        assert "UPDATE" in ProcessSQL.UPDATE_STEP_REPLY
+        assert "reply_outcome" in ProcessSQL.UPDATE_STEP_REPLY
+
+    def test_get_audit_trail_defined(self) -> None:
+        """GET_AUDIT_TRAIL SQL should be defined."""
+        assert ProcessSQL.GET_AUDIT_TRAIL is not None
+        assert "ORDER BY sent_at" in ProcessSQL.GET_AUDIT_TRAIL
+
+    def test_get_completed_steps_defined(self) -> None:
+        """GET_COMPLETED_STEPS SQL should be defined."""
+        assert ProcessSQL.GET_COMPLETED_STEPS is not None
+        assert "SUCCESS" in ProcessSQL.GET_COMPLETED_STEPS
+
+
+class TestProcessParams:
+    """Tests for ProcessParams static methods."""
+
+    def test_save_returns_tuple(self) -> None:
+        """save should return tuple with correct length."""
+        now = datetime.now(UTC)
+        process = ProcessMetadata(
+            domain="test",
+            process_id=uuid4(),
+            process_type="TestProcess",
+            status=ProcessStatus.PENDING,
+            current_step="step1",
+            state={"key": "value"},
+            created_at=now,
+            updated_at=now,
+        )
+        params = ProcessParams.save(process, {"key": "value"})
+
+        assert isinstance(params, tuple)
+        assert len(params) == 11
+        assert params[0] == "test"
+        assert params[3] == "PENDING"
+
+    def test_update_returns_tuple(self) -> None:
+        """update should return tuple with correct length."""
+        now = datetime.now(UTC)
+        process = ProcessMetadata(
+            domain="test",
+            process_id=uuid4(),
+            process_type="TestProcess",
+            status=ProcessStatus.IN_PROGRESS,
+            current_step="step2",
+            state={"key": "value"},
+            created_at=now,
+            updated_at=now,
+        )
+        params = ProcessParams.update(process, {"key": "value"})
+
+        assert isinstance(params, tuple)
+        assert len(params) == 8
+        assert params[0] == "IN_PROGRESS"
+
+    def test_get_by_id_returns_tuple(self) -> None:
+        """get_by_id should return tuple."""
+        process_id = uuid4()
+        params = ProcessParams.get_by_id("test", process_id)
+
+        assert params == ("test", process_id)
+
+    def test_find_by_status_converts_enum_values(self) -> None:
+        """find_by_status should convert status enums to values."""
+        statuses = [ProcessStatus.PENDING, ProcessStatus.IN_PROGRESS]
+        params = ProcessParams.find_by_status("test", statuses)
+
+        assert params[0] == "test"
+        assert params[1] == ["PENDING", "IN_PROGRESS"]
+
+    def test_log_step_returns_tuple(self) -> None:
+        """log_step should return tuple with correct length."""
+        entry = ProcessAuditEntry(
+            step_name="step1",
+            command_id=uuid4(),
+            command_type="TestCommand",
+            command_data={"key": "value"},
+            sent_at=datetime.now(UTC),
+        )
+        params = ProcessParams.log_step("test", uuid4(), entry)
+
+        assert isinstance(params, tuple)
+        assert len(params) == 10
+        assert params[2] == "step1"
+
+    def test_log_step_handles_none_data(self) -> None:
+        """log_step should handle None command_data."""
+        entry = ProcessAuditEntry(
+            step_name="step1",
+            command_id=uuid4(),
+            command_type="TestCommand",
+            command_data=None,
+            sent_at=datetime.now(UTC),
+        )
+        params = ProcessParams.log_step("test", uuid4(), entry)
+
+        assert params[5] is None
+
+    def test_log_step_serializes_reply_outcome(self) -> None:
+        """log_step should serialize reply_outcome to value."""
+        entry = ProcessAuditEntry(
+            step_name="step1",
+            command_id=uuid4(),
+            command_type="TestCommand",
+            command_data=None,
+            sent_at=datetime.now(UTC),
+            reply_outcome=ReplyOutcome.SUCCESS,
+        )
+        params = ProcessParams.log_step("test", uuid4(), entry)
+
+        assert params[7] == "SUCCESS"
+
+    def test_update_step_reply_returns_tuple(self) -> None:
+        """update_step_reply should return tuple with correct length."""
+        entry = ProcessAuditEntry(
+            step_name="step1",
+            command_id=uuid4(),
+            command_type="TestCommand",
+            command_data=None,
+            sent_at=datetime.now(UTC),
+            reply_outcome=ReplyOutcome.SUCCESS,
+            reply_data={"result": "ok"},
+            received_at=datetime.now(UTC),
+        )
+        params = ProcessParams.update_step_reply("test", uuid4(), uuid4(), entry)
+
+        assert isinstance(params, tuple)
+        assert len(params) == 6
+        assert params[0] == "SUCCESS"
+
+    def test_get_audit_trail_returns_tuple(self) -> None:
+        """get_audit_trail should return tuple."""
+        process_id = uuid4()
+        params = ProcessParams.get_audit_trail("test", process_id)
+
+        assert params == ("test", process_id)
+
+    def test_get_completed_steps_returns_tuple(self) -> None:
+        """get_completed_steps should return tuple."""
+        process_id = uuid4()
+        params = ProcessParams.get_completed_steps("test", process_id)
+
+        assert params == ("test", process_id)
+
+
+class TestProcessParsers:
+    """Tests for ProcessParsers static methods."""
+
+    def test_from_row_parses_metadata(self) -> None:
+        """from_row should parse database row to ProcessMetadata."""
+        now = datetime.now(UTC)
+        process_id = uuid4()
+        row = (
+            "test",
+            process_id,
+            "TestProcess",
+            "PENDING",
+            "step1",
+            {"key": "value"},
+            None,
+            None,
+            now,
+            now,
+            None,
+        )
+
+        result = ProcessParsers.from_row(row)
+
+        assert isinstance(result, ProcessMetadata)
+        assert result.domain == "test"
+        assert result.process_id == process_id
+        assert result.process_type == "TestProcess"
+        assert result.status == ProcessStatus.PENDING
+        assert result.current_step == "step1"
+        assert result.state == {"key": "value"}
+
+    def test_from_row_parses_json_string_state(self) -> None:
+        """from_row should parse JSON string state."""
+        now = datetime.now(UTC)
+        row = (
+            "test",
+            uuid4(),
+            "TestProcess",
+            "IN_PROGRESS",
+            "step2",
+            '{"key": "value"}',  # JSON string
+            None,
+            None,
+            now,
+            now,
+            None,
+        )
+
+        result = ProcessParsers.from_row(row)
+
+        assert result.state == {"key": "value"}
+
+    def test_from_rows_parses_list(self) -> None:
+        """from_rows should parse list of rows."""
+        now = datetime.now(UTC)
+        rows = [
+            ("test", uuid4(), "TestProcess", "PENDING", "step1", {}, None, None, now, now, None),
+            (
+                "test",
+                uuid4(),
+                "TestProcess",
+                "IN_PROGRESS",
+                "step2",
+                {},
+                None,
+                None,
+                now,
+                now,
+                None,
+            ),
+        ]
+
+        result = ProcessParsers.from_rows(rows)
+
+        assert len(result) == 2
+        assert all(isinstance(p, ProcessMetadata) for p in result)
+
+    def test_audit_entry_from_row_parses_entry(self) -> None:
+        """audit_entry_from_row should parse database row to ProcessAuditEntry."""
+        now = datetime.now(UTC)
+        command_id = uuid4()
+        row = (
+            "step1",
+            command_id,
+            "TestCommand",
+            {"key": "value"},
+            now,
+            "SUCCESS",
+            {"result": "ok"},
+            now,
+        )
+
+        result = ProcessParsers.audit_entry_from_row(row)
+
+        assert isinstance(result, ProcessAuditEntry)
+        assert result.step_name == "step1"
+        assert result.command_id == command_id
+        assert result.command_type == "TestCommand"
+        assert result.command_data == {"key": "value"}
+        assert result.reply_outcome == ReplyOutcome.SUCCESS
+        assert result.reply_data == {"result": "ok"}
+
+    def test_audit_entry_from_row_handles_none_outcome(self) -> None:
+        """audit_entry_from_row should handle None reply_outcome."""
+        now = datetime.now(UTC)
+        row = (
+            "step1",
+            uuid4(),
+            "TestCommand",
+            None,
+            now,
+            None,  # No reply yet
+            None,
+            None,
+        )
+
+        result = ProcessParsers.audit_entry_from_row(row)
+
+        assert result.reply_outcome is None
+
+    def test_audit_entry_from_row_parses_json_strings(self) -> None:
+        """audit_entry_from_row should parse JSON string data."""
+        now = datetime.now(UTC)
+        row = (
+            "step1",
+            uuid4(),
+            "TestCommand",
+            '{"key": "value"}',  # JSON string
+            now,
+            "SUCCESS",
+            '{"result": "ok"}',  # JSON string
+            now,
+        )
+
+        result = ProcessParsers.audit_entry_from_row(row)
+
+        assert result.command_data == {"key": "value"}
+        assert result.reply_data == {"result": "ok"}
+
+    def test_audit_entries_from_rows_parses_list(self) -> None:
+        """audit_entries_from_rows should parse list of rows."""
+        now = datetime.now(UTC)
+        rows = [
+            ("step1", uuid4(), "TestCommand", None, now, None, None, None),
+            ("step2", uuid4(), "TestCommand", None, now, "SUCCESS", None, now),
+        ]
+
+        result = ProcessParsers.audit_entries_from_rows(rows)
+
+        assert len(result) == 2
+        assert all(isinstance(e, ProcessAuditEntry) for e in result)

--- a/tests/unit/sync/test_sync_process_repository.py
+++ b/tests/unit/sync/test_sync_process_repository.py
@@ -1,0 +1,667 @@
+"""Unit tests for commandbus.sync.repositories.process module."""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from commandbus._core.process_sql import ProcessSQL
+from commandbus.models import ReplyOutcome
+from commandbus.process.models import (
+    ProcessAuditEntry,
+    ProcessMetadata,
+    ProcessStatus,
+)
+from commandbus.sync.repositories.process import SyncProcessRepository
+
+
+def make_process_metadata(
+    domain: str = "test",
+    process_id: str | None = None,
+    process_type: str = "TestProcess",
+    status: ProcessStatus = ProcessStatus.PENDING,
+    current_step: str = "step1",
+) -> ProcessMetadata:
+    """Create a ProcessMetadata for testing."""
+    now = datetime.now(UTC)
+    return ProcessMetadata(
+        domain=domain,
+        process_id=uuid4() if process_id is None else process_id,
+        process_type=process_type,
+        status=status,
+        current_step=current_step,
+        state={"key": "value"},
+        error_code=None,
+        error_message=None,
+        created_at=now,
+        updated_at=now,
+        completed_at=None,
+    )
+
+
+def make_audit_entry(
+    step_name: str = "step1",
+    reply_outcome: ReplyOutcome | None = None,
+) -> ProcessAuditEntry:
+    """Create a ProcessAuditEntry for testing."""
+    now = datetime.now(UTC)
+    return ProcessAuditEntry(
+        step_name=step_name,
+        command_id=uuid4(),
+        command_type="TestCommand",
+        command_data={"key": "value"},
+        sent_at=now,
+        reply_outcome=reply_outcome,
+        reply_data={"result": "ok"} if reply_outcome else None,
+        received_at=now if reply_outcome else None,
+    )
+
+
+def make_row_from_process(process: ProcessMetadata) -> tuple:
+    """Create a database row tuple from ProcessMetadata."""
+    return (
+        process.domain,
+        process.process_id,
+        process.process_type,
+        process.status.value,
+        process.current_step,
+        process.state,
+        process.error_code,
+        process.error_message,
+        process.created_at,
+        process.updated_at,
+        process.completed_at,
+    )
+
+
+def make_row_from_audit_entry(entry: ProcessAuditEntry) -> tuple:
+    """Create a database row tuple from ProcessAuditEntry."""
+    return (
+        entry.step_name,
+        entry.command_id,
+        entry.command_type,
+        entry.command_data,
+        entry.sent_at,
+        entry.reply_outcome.value if entry.reply_outcome else None,
+        entry.reply_data,
+        entry.received_at,
+    )
+
+
+class TestSyncProcessRepositoryInit:
+    """Tests for SyncProcessRepository initialization."""
+
+    def test_init_stores_pool(self) -> None:
+        """SyncProcessRepository should store the pool reference."""
+        pool = MagicMock()
+        repo = SyncProcessRepository(pool)
+        assert repo._pool is pool
+
+
+class TestSyncProcessRepositorySave:
+    """Tests for SyncProcessRepository.save method."""
+
+    def test_save_with_pool(self) -> None:
+        """save should use pool when no connection provided."""
+        pool = MagicMock()
+        conn = MagicMock()
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        process = make_process_metadata()
+        repo.save(process)
+
+        conn.execute.assert_called_once()
+        args = conn.execute.call_args
+        assert args[0][0] == ProcessSQL.SAVE
+
+    def test_save_with_provided_connection(self) -> None:
+        """save should use provided connection."""
+        pool = MagicMock()
+        conn = MagicMock()
+
+        repo = SyncProcessRepository(pool)
+        process = make_process_metadata()
+        repo.save(process, conn=conn)
+
+        conn.execute.assert_called_once()
+        pool.connection.assert_not_called()
+
+    def test_save_serializes_state(self) -> None:
+        """save should serialize state to JSON."""
+        pool = MagicMock()
+        conn = MagicMock()
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        process = make_process_metadata()
+        repo.save(process)
+
+        args = conn.execute.call_args
+        params = args[0][1]
+        # Verify state is serialized (6th param, index 5)
+        assert '"key"' in params[5]  # JSON string contains key
+
+    def test_save_with_to_dict_state(self) -> None:
+        """save should call to_dict() on state if available."""
+        pool = MagicMock()
+        conn = MagicMock()
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        state_obj = MagicMock()
+        state_obj.to_dict.return_value = {"custom": "state"}
+
+        repo = SyncProcessRepository(pool)
+        process = make_process_metadata()
+        process.state = state_obj
+        repo.save(process)
+
+        state_obj.to_dict.assert_called_once()
+
+
+class TestSyncProcessRepositoryUpdate:
+    """Tests for SyncProcessRepository.update method."""
+
+    def test_update_with_pool(self) -> None:
+        """update should use pool when no connection provided."""
+        pool = MagicMock()
+        conn = MagicMock()
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        process = make_process_metadata(status=ProcessStatus.IN_PROGRESS)
+        repo.update(process)
+
+        conn.execute.assert_called_once()
+        args = conn.execute.call_args
+        assert args[0][0] == ProcessSQL.UPDATE
+
+    def test_update_with_provided_connection(self) -> None:
+        """update should use provided connection."""
+        pool = MagicMock()
+        conn = MagicMock()
+
+        repo = SyncProcessRepository(pool)
+        process = make_process_metadata()
+        repo.update(process, conn=conn)
+
+        conn.execute.assert_called_once()
+        pool.connection.assert_not_called()
+
+    def test_update_serializes_state(self) -> None:
+        """update should serialize state to JSON."""
+        pool = MagicMock()
+        conn = MagicMock()
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        process = make_process_metadata()
+        repo.update(process)
+
+        args = conn.execute.call_args
+        params = args[0][1]
+        # Verify state is serialized (3rd param, index 2)
+        assert '"key"' in params[2]
+
+    def test_update_with_to_dict_state(self) -> None:
+        """update should call to_dict() on state if available."""
+        pool = MagicMock()
+        conn = MagicMock()
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        state_obj = MagicMock()
+        state_obj.to_dict.return_value = {"custom": "state"}
+
+        repo = SyncProcessRepository(pool)
+        process = make_process_metadata()
+        process.state = state_obj
+        repo.update(process)
+
+        state_obj.to_dict.assert_called_once()
+
+
+class TestSyncProcessRepositoryGetById:
+    """Tests for SyncProcessRepository.get_by_id method."""
+
+    def test_get_by_id_returns_process(self) -> None:
+        """get_by_id should return ProcessMetadata when found."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+
+        process = make_process_metadata()
+        row = make_row_from_process(process)
+        cursor.fetchone.return_value = row
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        result = repo.get_by_id("test", process.process_id)
+
+        assert result is not None
+        assert result.domain == process.domain
+        assert result.process_id == process.process_id
+        assert result.process_type == process.process_type
+
+    def test_get_by_id_returns_none_when_not_found(self) -> None:
+        """get_by_id should return None when process not found."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchone.return_value = None
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        result = repo.get_by_id("test", uuid4())
+
+        assert result is None
+
+    def test_get_by_id_executes_correct_sql(self) -> None:
+        """get_by_id should execute GET_BY_ID SQL."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchone.return_value = None
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        process_id = uuid4()
+        repo.get_by_id("test", process_id)
+
+        args = cursor.execute.call_args
+        assert args[0][0] == ProcessSQL.GET_BY_ID
+        assert args[0][1] == ("test", process_id)
+
+    def test_get_by_id_with_provided_connection(self) -> None:
+        """get_by_id should use provided connection."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchone.return_value = None
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+
+        repo = SyncProcessRepository(pool)
+        repo.get_by_id("test", uuid4(), conn=conn)
+
+        pool.connection.assert_not_called()
+
+
+class TestSyncProcessRepositoryFindByStatus:
+    """Tests for SyncProcessRepository.find_by_status method."""
+
+    def test_find_by_status_returns_list(self) -> None:
+        """find_by_status should return list of ProcessMetadata."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+
+        process1 = make_process_metadata()
+        process2 = make_process_metadata()
+        rows = [make_row_from_process(process1), make_row_from_process(process2)]
+        cursor.fetchall.return_value = rows
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        result = repo.find_by_status("test", [ProcessStatus.PENDING])
+
+        assert len(result) == 2
+        assert all(isinstance(p, ProcessMetadata) for p in result)
+
+    def test_find_by_status_returns_empty_list(self) -> None:
+        """find_by_status should return empty list when no matches."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        result = repo.find_by_status("test", [ProcessStatus.COMPLETED])
+
+        assert result == []
+
+    def test_find_by_status_executes_correct_sql(self) -> None:
+        """find_by_status should execute FIND_BY_STATUS SQL."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        repo.find_by_status("test", [ProcessStatus.PENDING, ProcessStatus.IN_PROGRESS])
+
+        args = cursor.execute.call_args
+        assert args[0][0] == ProcessSQL.FIND_BY_STATUS
+        assert args[0][1] == ("test", ["PENDING", "IN_PROGRESS"])
+
+    def test_find_by_status_with_provided_connection(self) -> None:
+        """find_by_status should use provided connection."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+
+        repo = SyncProcessRepository(pool)
+        repo.find_by_status("test", [ProcessStatus.PENDING], conn=conn)
+
+        pool.connection.assert_not_called()
+
+
+class TestSyncProcessRepositoryLogStep:
+    """Tests for SyncProcessRepository.log_step method."""
+
+    def test_log_step_with_pool(self) -> None:
+        """log_step should use pool when no connection provided."""
+        pool = MagicMock()
+        conn = MagicMock()
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        entry = make_audit_entry()
+        repo.log_step("test", uuid4(), entry)
+
+        conn.execute.assert_called_once()
+        args = conn.execute.call_args
+        assert args[0][0] == ProcessSQL.LOG_STEP
+
+    def test_log_step_with_provided_connection(self) -> None:
+        """log_step should use provided connection."""
+        pool = MagicMock()
+        conn = MagicMock()
+
+        repo = SyncProcessRepository(pool)
+        entry = make_audit_entry()
+        repo.log_step("test", uuid4(), entry, conn=conn)
+
+        conn.execute.assert_called_once()
+        pool.connection.assert_not_called()
+
+    def test_log_step_includes_reply_outcome(self) -> None:
+        """log_step should include reply_outcome when present."""
+        pool = MagicMock()
+        conn = MagicMock()
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        entry = make_audit_entry(reply_outcome=ReplyOutcome.SUCCESS)
+        repo.log_step("test", uuid4(), entry)
+
+        args = conn.execute.call_args
+        params = args[0][1]
+        # reply_outcome is at index 7
+        assert params[7] == "SUCCESS"
+
+
+class TestSyncProcessRepositoryUpdateStepReply:
+    """Tests for SyncProcessRepository.update_step_reply method."""
+
+    def test_update_step_reply_with_pool(self) -> None:
+        """update_step_reply should use pool when no connection provided."""
+        pool = MagicMock()
+        conn = MagicMock()
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        entry = make_audit_entry(reply_outcome=ReplyOutcome.SUCCESS)
+        repo.update_step_reply("test", uuid4(), uuid4(), entry)
+
+        conn.execute.assert_called_once()
+        args = conn.execute.call_args
+        assert args[0][0] == ProcessSQL.UPDATE_STEP_REPLY
+
+    def test_update_step_reply_with_provided_connection(self) -> None:
+        """update_step_reply should use provided connection."""
+        pool = MagicMock()
+        conn = MagicMock()
+
+        repo = SyncProcessRepository(pool)
+        entry = make_audit_entry(reply_outcome=ReplyOutcome.SUCCESS)
+        repo.update_step_reply("test", uuid4(), uuid4(), entry, conn=conn)
+
+        conn.execute.assert_called_once()
+        pool.connection.assert_not_called()
+
+    def test_update_step_reply_params(self) -> None:
+        """update_step_reply should pass correct parameters."""
+        pool = MagicMock()
+        conn = MagicMock()
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        entry = make_audit_entry(reply_outcome=ReplyOutcome.FAILED)
+        process_id = uuid4()
+        command_id = uuid4()
+        repo.update_step_reply("test", process_id, command_id, entry)
+
+        args = conn.execute.call_args
+        params = args[0][1]
+        assert params[0] == "FAILED"  # reply_outcome
+        assert params[3] == "test"  # domain
+        assert params[4] == process_id
+        assert params[5] == command_id
+
+
+class TestSyncProcessRepositoryGetAuditTrail:
+    """Tests for SyncProcessRepository.get_audit_trail method."""
+
+    def test_get_audit_trail_returns_list(self) -> None:
+        """get_audit_trail should return list of ProcessAuditEntry."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+
+        entry1 = make_audit_entry("step1")
+        entry2 = make_audit_entry("step2", reply_outcome=ReplyOutcome.SUCCESS)
+        rows = [
+            make_row_from_audit_entry(entry1),
+            make_row_from_audit_entry(entry2),
+        ]
+        cursor.fetchall.return_value = rows
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        result = repo.get_audit_trail("test", uuid4())
+
+        assert len(result) == 2
+        assert all(isinstance(e, ProcessAuditEntry) for e in result)
+        assert result[0].step_name == "step1"
+        assert result[1].step_name == "step2"
+
+    def test_get_audit_trail_returns_empty_list(self) -> None:
+        """get_audit_trail should return empty list when no entries."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        result = repo.get_audit_trail("test", uuid4())
+
+        assert result == []
+
+    def test_get_audit_trail_executes_correct_sql(self) -> None:
+        """get_audit_trail should execute GET_AUDIT_TRAIL SQL."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        process_id = uuid4()
+        repo.get_audit_trail("test", process_id)
+
+        args = cursor.execute.call_args
+        assert args[0][0] == ProcessSQL.GET_AUDIT_TRAIL
+        assert args[0][1] == ("test", process_id)
+
+    def test_get_audit_trail_with_provided_connection(self) -> None:
+        """get_audit_trail should use provided connection."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+
+        repo = SyncProcessRepository(pool)
+        repo.get_audit_trail("test", uuid4(), conn=conn)
+
+        pool.connection.assert_not_called()
+
+
+class TestSyncProcessRepositoryGetCompletedSteps:
+    """Tests for SyncProcessRepository.get_completed_steps method."""
+
+    def test_get_completed_steps_returns_list(self) -> None:
+        """get_completed_steps should return list of step names."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [("step1",), ("step2",), ("step3",)]
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        result = repo.get_completed_steps("test", uuid4())
+
+        assert result == ["step1", "step2", "step3"]
+
+    def test_get_completed_steps_returns_empty_list(self) -> None:
+        """get_completed_steps should return empty list when no completed steps."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        result = repo.get_completed_steps("test", uuid4())
+
+        assert result == []
+
+    def test_get_completed_steps_executes_correct_sql(self) -> None:
+        """get_completed_steps should execute GET_COMPLETED_STEPS SQL."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+        pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+        pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        repo = SyncProcessRepository(pool)
+        process_id = uuid4()
+        repo.get_completed_steps("test", process_id)
+
+        args = cursor.execute.call_args
+        assert args[0][0] == ProcessSQL.GET_COMPLETED_STEPS
+        assert args[0][1] == ("test", process_id)
+
+    def test_get_completed_steps_with_provided_connection(self) -> None:
+        """get_completed_steps should use provided connection."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+
+        repo = SyncProcessRepository(pool)
+        repo.get_completed_steps("test", uuid4(), conn=conn)
+
+        pool.connection.assert_not_called()
+
+
+class TestSyncProcessRepositoryTransactionSupport:
+    """Tests for transaction support across all methods."""
+
+    def test_all_methods_support_provided_connection(self) -> None:
+        """All methods should accept and use provided connection."""
+        pool = MagicMock()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = []
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+
+        repo = SyncProcessRepository(pool)
+        process = make_process_metadata()
+        entry = make_audit_entry(reply_outcome=ReplyOutcome.SUCCESS)
+
+        # All methods with conn parameter
+        repo.save(process, conn=conn)
+        repo.update(process, conn=conn)
+        repo.get_by_id("test", uuid4(), conn=conn)
+        repo.find_by_status("test", [ProcessStatus.PENDING], conn=conn)
+        repo.log_step("test", uuid4(), entry, conn=conn)
+        repo.update_step_reply("test", uuid4(), uuid4(), entry, conn=conn)
+        repo.get_audit_trail("test", uuid4(), conn=conn)
+        repo.get_completed_steps("test", uuid4(), conn=conn)
+
+        # Pool should never be accessed
+        pool.connection.assert_not_called()


### PR DESCRIPTION
## Summary

Implements S079 from the F015 sync refactor feature:
- Add `ProcessSQL`, `ProcessParams`, `ProcessParsers` to `_core/process_sql.py` for shared SQL logic
- Add `SyncProcessRepository` with full CRUD operations using psycopg3's synchronous ConnectionPool
- Support `ProcessMetadata` and `ProcessAuditEntry` persistence
- All methods support optional `conn` parameter for transaction participation

## Changes

- **`src/commandbus/_core/__init__.py`** - Export process SQL classes
- **`src/commandbus/_core/process_sql.py`** - SQL constants, parameter builders, row parsers
- **`src/commandbus/sync/repositories/__init__.py`** - Export `SyncProcessRepository`
- **`src/commandbus/sync/repositories/process.py`** - Full sync repository implementation

## Test plan

- [x] Unit tests for `ProcessSQL`, `ProcessParams`, `ProcessParsers` (100% coverage)
- [x] Unit tests for `SyncProcessRepository` (100% coverage)
- [x] All existing tests continue to pass
- [x] Coverage remains above 80% (84.32%)

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)