### PR TITLE
feat: Add native synchronous Worker (S082)

### DIFF
--- a/src/commandbus/sync/worker.py
+++ b/src/commandbus/sync/worker.py
@@ -1,99 +1,676 @@
-"""Blocking worker wrapper."""
+"""Native synchronous worker for processing commands.
+
+This module provides a native sync worker using ThreadPoolExecutor for
+concurrency, without the overhead of async wrapper patterns.
+"""
 
 from __future__ import annotations
 
 import logging
 import threading
-from concurrent.futures import ThreadPoolExecutor
+import time
+from concurrent.futures import Future, ThreadPoolExecutor, wait
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+from uuid import UUID
 
-from commandbus.sync.config import get_default_runtime, get_thread_pool_size
-from commandbus.worker import Worker
+from commandbus.batch import invoke_sync_batch_callback
+from commandbus.exceptions import PermanentCommandError, TransientCommandError
+from commandbus.models import (
+    Command,
+    CommandMetadata,
+    CommandStatus,
+    HandlerContext,
+    ReplyOutcome,
+)
+from commandbus.policies import DEFAULT_RETRY_POLICY, RetryPolicy
+from commandbus.sync.health import HealthStatus
+from commandbus.sync.pgmq import SyncPgmqClient
+from commandbus.sync.repositories.audit import SyncAuditLogger
+from commandbus.sync.repositories.batch import SyncBatchRepository
+from commandbus.sync.repositories.command import SyncCommandRepository
 
 if TYPE_CHECKING:
-    from concurrent.futures import Future
+    from psycopg import Connection
+    from psycopg_pool import ConnectionPool
 
-    from commandbus.sync.runtime import SyncRuntime
-
+    from commandbus.handler import HandlerRegistry
 
 logger = logging.getLogger(__name__)
 
 
+def _make_queue_name(domain: str, suffix: str = "commands") -> str:
+    """Create a queue name from domain."""
+    return f"{domain}__{suffix}"
+
+
+@dataclass
+class ReceivedCommand:
+    """A command received from the queue, ready for processing.
+
+    Attributes:
+        command: The command to process
+        context: Handler context with attempt info
+        msg_id: PGMQ message ID for acknowledgment
+        metadata: Command metadata from storage
+    """
+
+    command: Command
+    context: HandlerContext
+    msg_id: int
+    metadata: CommandMetadata
+
+
 class SyncWorker:
-    """Synchronous adapter for :class:`commandbus.worker.Worker`."""
+    """Native synchronous worker for processing commands.
+
+    The worker uses a ThreadPoolExecutor for concurrent command processing,
+    polling the queue for messages and dispatching handlers in worker threads.
+
+    Example:
+        pool = ConnectionPool(conninfo=DATABASE_URL)
+        registry = HandlerRegistry()
+
+        @registry.sync_handler("payments", "DebitAccount")
+        def handle_debit(command, context):
+            return {"processed": True}
+
+        worker = SyncWorker(pool, domain="payments", registry=registry)
+        worker.run(concurrency=4)  # Blocks until stop() is called
+    """
 
     def __init__(
         self,
-        *args: Any,
-        worker: Worker | None = None,
-        runtime: SyncRuntime | None = None,
-        thread_pool_size: int | None = None,
-        **kwargs: Any,
-    ) -> None:
-        if worker is None and not args and not kwargs:
-            raise ValueError("SyncWorker requires a Worker or constructor arguments")
-        self._worker = worker or Worker(*args, **kwargs)
-        self._runtime = get_default_runtime(runtime)
-        self._executor = ThreadPoolExecutor(max_workers=get_thread_pool_size(thread_pool_size))
-        self._future_lock = threading.Lock()
-        self._run_future: Future[None] | None = None
-        self._is_running = False
-
-    def run(
-        self,
+        pool: ConnectionPool[Any],
+        domain: str,
+        registry: HandlerRegistry | None = None,
         *,
-        block: bool = True,
-        concurrency: int = 1,
-        poll_interval: float = 1.0,
-        use_notify: bool = True,
+        visibility_timeout: int = 30,
+        retry_policy: RetryPolicy | None = None,
+        statement_timeout: int = 25000,
     ) -> None:
-        """Start the worker loop in a background thread."""
+        """Initialize the sync worker.
 
-        def _target() -> None:
-            try:
-                self._runtime.run(
-                    self._worker.run(
-                        concurrency=concurrency,
-                        poll_interval=poll_interval,
-                        use_notify=use_notify,
-                    )
-                )
-            except Exception:
-                logger.exception(f"Sync wrapper for {self._worker.domain} crashed")
-                raise
+        Args:
+            pool: psycopg sync connection pool
+            domain: The domain to process commands for
+            registry: Handler registry for dispatching commands
+            visibility_timeout: Default visibility timeout in seconds
+            retry_policy: Policy for retry behavior and backoff
+            statement_timeout: PostgreSQL statement timeout in milliseconds
+        """
+        self._pool = pool
+        self._domain = domain
+        self._registry = registry
+        self._visibility_timeout = visibility_timeout
+        self._retry_policy = retry_policy or DEFAULT_RETRY_POLICY
+        self._statement_timeout = statement_timeout
+        self._queue_name = _make_queue_name(domain)
 
-        with self._future_lock:
-            if self._is_running:
-                raise RuntimeError("Worker is already running")
-            if self._run_future is not None and not self._run_future.done():
-                raise RuntimeError("Worker is already running")
-            self._is_running = True
-            self._run_future = self._executor.submit(_target)
+        # Sync components
+        self._pgmq = SyncPgmqClient(pool)
+        self._command_repo = SyncCommandRepository(pool)
+        self._batch_repo = SyncBatchRepository(pool)
+        self._audit_logger = SyncAuditLogger(pool)
 
-        if block:
-            self._run_future.result()
-
-    def stop(self, *, timeout: float | None = None) -> None:
-        """Signal the worker to stop and wait for completion."""
-        self._runtime.run(self._worker.stop(timeout=timeout))
-        with self._future_lock:
-            future = self._run_future
-            self._is_running = False
-        if future is not None:
-            future.result(timeout)
-
-    def shutdown(self) -> None:
-        """Stop the worker (if running) and release resources."""
-        with self._future_lock:
-            future = self._run_future
-        if future is not None and not future.done():
-            self.stop()
-        else:
-            with self._future_lock:
-                self._is_running = False
-        self._executor.shutdown(wait=True)
+        # Runtime state
+        self._executor: ThreadPoolExecutor | None = None
+        self._stop_event = threading.Event()
+        self._in_flight: dict[int, tuple[Future[None], float]] = {}
+        self._in_flight_lock = threading.Lock()
+        self._health = HealthStatus()
+        self._concurrency = 1
 
     @property
     def domain(self) -> str:
-        """Expose wrapped worker domain for diagnostics."""
-        return self._worker.domain
+        """Get the domain this worker processes."""
+        return self._domain
+
+    @property
+    def queue_name(self) -> str:
+        """Get the queue name this worker reads from."""
+        return self._queue_name
+
+    @property
+    def health_status(self) -> HealthStatus:
+        """Get the health status tracker."""
+        return self._health
+
+    @property
+    def is_running(self) -> bool:
+        """Check if the worker is currently running."""
+        return self._executor is not None and not self._stop_event.is_set()
+
+    @property
+    def in_flight_count(self) -> int:
+        """Get the number of commands currently being processed."""
+        with self._in_flight_lock:
+            return len(self._in_flight)
+
+    def run(
+        self,
+        concurrency: int = 4,
+        poll_interval: float = 1.0,
+    ) -> None:
+        """Run the worker continuously, processing commands.
+
+        This method blocks until stop() is called. Commands are processed
+        concurrently using a ThreadPoolExecutor with the specified concurrency.
+
+        Args:
+            concurrency: Maximum number of commands to process concurrently
+            poll_interval: Seconds between queue polls when idle
+
+        Raises:
+            RuntimeError: If no handler registry is configured
+        """
+        if self._registry is None:
+            raise RuntimeError("Cannot run worker without a handler registry")
+
+        self._concurrency = concurrency
+        self._stop_event.clear()
+        self._executor = ThreadPoolExecutor(
+            max_workers=concurrency,
+            thread_name_prefix=f"worker-{self._domain}",
+        )
+
+        logger.info(
+            f"Starting sync worker for {self._domain} "
+            f"(concurrency={concurrency}, poll_interval={poll_interval}s)"
+        )
+
+        try:
+            self._run_loop(poll_interval)
+        except Exception:
+            logger.exception(f"Sync worker for {self._domain} crashed")
+            raise
+        finally:
+            self._drain_in_flight()
+            if self._executor is not None:
+                self._executor.shutdown(wait=True)
+                self._executor = None
+            logger.info(f"Sync worker for {self._domain} stopped")
+
+    def _run_loop(self, poll_interval: float) -> None:
+        """Main worker loop - poll and dispatch commands."""
+        while not self._stop_event.is_set():
+            try:
+                self._poll_and_dispatch()
+
+                # Check for completed tasks and clean up
+                self._cleanup_completed()
+
+                # Check for stuck threads
+                self._check_stuck_threads()
+
+                # If at capacity, wait for a slot
+                with self._in_flight_lock:
+                    available = self._concurrency - len(self._in_flight)
+
+                if available <= 0:
+                    self._wait_for_slot(timeout=poll_interval)
+                elif self._stop_event.wait(timeout=poll_interval):
+                    # Short sleep to avoid busy-waiting, or stop requested
+                    break
+
+            except Exception:
+                logger.exception("Error in worker poll loop")
+                self._health.record_failure()
+                # Brief pause before retrying
+                if self._stop_event.wait(timeout=1.0):
+                    break
+
+    def _poll_and_dispatch(self) -> None:
+        """Poll for messages and dispatch to thread pool."""
+        with self._in_flight_lock:
+            available = self._concurrency - len(self._in_flight)
+
+        if available <= 0:
+            return
+
+        # Read messages from queue
+        received_commands = self._receive(batch_size=available)
+
+        for received in received_commands:
+            future = self._executor.submit(self._process_command, received)  # type: ignore[union-attr]
+            with self._in_flight_lock:
+                self._in_flight[received.msg_id] = (future, time.monotonic())
+
+    def _receive(
+        self,
+        batch_size: int = 1,
+        visibility_timeout: int | None = None,
+    ) -> list[ReceivedCommand]:
+        """Receive commands from the queue.
+
+        Args:
+            batch_size: Maximum number of commands to receive
+            visibility_timeout: Override default visibility timeout
+
+        Returns:
+            List of received commands (may be empty)
+        """
+        vt = visibility_timeout or self._visibility_timeout
+        received: list[ReceivedCommand] = []
+
+        with self._pool.connection() as conn:
+            # Set statement timeout for this connection
+            conn.execute(f"SET statement_timeout = {self._statement_timeout}")
+
+            messages = self._pgmq.read(
+                self._queue_name,
+                visibility_timeout=vt,
+                batch_size=batch_size,
+                conn=conn,
+            )
+
+            for msg in messages:
+                try:
+                    result = self._process_message(msg.msg_id, msg.message, conn)
+                    if result is not None:
+                        received.append(result)
+                except Exception:
+                    logger.exception(f"Error processing message {msg.msg_id}")
+                    # Message will reappear after visibility timeout
+
+        return received
+
+    def _process_message(
+        self,
+        msg_id: int,
+        message: dict[str, Any],
+        conn: Connection[Any],
+    ) -> ReceivedCommand | None:
+        """Process a single message from the queue.
+
+        Args:
+            msg_id: PGMQ message ID
+            message: Message payload
+            conn: Database connection
+
+        Returns:
+            ReceivedCommand if ready for processing, None if skipped
+        """
+        domain = message.get("domain", self._domain)
+        command_id_str = message.get("command_id")
+        if not command_id_str:
+            logger.warning(f"Message {msg_id} missing command_id, archiving")
+            self._pgmq.archive(self._queue_name, msg_id, conn)
+            return None
+
+        command_id = UUID(command_id_str)
+
+        # Use stored procedure to receive command
+        result = self._command_repo.sp_receive_command(domain, command_id, msg_id=msg_id, conn=conn)
+
+        if result is None:
+            logger.warning(f"No metadata for command {command_id} in domain {domain}, archiving")
+            self._pgmq.archive(self._queue_name, msg_id, conn)
+            return None
+
+        metadata, attempts = result
+
+        # Build command object
+        correlation_id_str = message.get("correlation_id")
+        command = Command(
+            domain=domain,
+            command_type=message.get("command_type", metadata.command_type),
+            command_id=command_id,
+            data=message.get("data", {}),
+            correlation_id=UUID(correlation_id_str) if correlation_id_str else None,
+            reply_to=message.get("reply_to"),
+            created_at=metadata.created_at,
+        )
+
+        # Build context
+        context = HandlerContext(
+            command=command,
+            attempt=attempts,
+            max_attempts=metadata.max_attempts,
+            msg_id=msg_id,
+        )
+
+        logger.info(
+            f"Received command {domain}.{command.command_type} "
+            f"(command_id={command_id}, attempt={attempts}/{metadata.max_attempts})"
+        )
+
+        return ReceivedCommand(
+            command=command,
+            context=context,
+            msg_id=msg_id,
+            metadata=metadata,
+        )
+
+    def _process_command(self, received: ReceivedCommand) -> None:
+        """Process a single command in a worker thread.
+
+        Args:
+            received: The received command to process
+        """
+        assert self._registry is not None
+
+        try:
+            context = HandlerContext(
+                command=received.command,
+                attempt=received.context.attempt,
+                max_attempts=received.context.max_attempts,
+                msg_id=received.msg_id,
+                visibility_extender=received.context.visibility_extender,
+            )
+
+            result = self._registry.dispatch_sync(received.command, context)
+
+            # Complete in separate connection/transaction
+            self._complete(received, result=result)
+            self._health.record_success()
+
+        except TransientCommandError as e:
+            # Explicit transient error - apply backoff and retry
+            self._fail(received, e, is_transient=True)
+            self._health.record_failure(e)
+        except PermanentCommandError as e:
+            # Permanent error - move to troubleshooting queue
+            self._fail_permanent(received, e)
+            self._health.record_failure(e)
+        except Exception as e:
+            # Unknown exception treated as transient
+            logger.exception(f"Error processing command {received.command.command_id}")
+            self._fail(received, e, is_transient=True)
+            self._health.record_failure(e)
+        finally:
+            # Remove from in-flight tracking
+            with self._in_flight_lock:
+                self._in_flight.pop(received.msg_id, None)
+
+    def _complete(
+        self,
+        received: ReceivedCommand,
+        result: dict[str, Any] | None = None,
+    ) -> None:
+        """Complete a command successfully.
+
+        Args:
+            received: The received command to complete
+            result: Optional result data to include in the reply
+        """
+        command = received.command
+        command_id = command.command_id
+        domain = command.domain
+
+        with self._pool.connection() as conn, conn.transaction():
+            # Delete message from queue
+            self._pgmq.delete(self._queue_name, received.msg_id, conn)
+
+            # Use stored procedure to finish command
+            is_batch_complete = self._command_repo.sp_finish_command(
+                domain,
+                command_id,
+                CommandStatus.COMPLETED,
+                event_type="COMPLETED",
+                details={
+                    "msg_id": received.msg_id,
+                    "reply_to": command.reply_to,
+                    "has_result": result is not None,
+                },
+                batch_id=received.metadata.batch_id,
+                conn=conn,
+            )
+
+            # Send reply if reply_to is configured
+            if command.reply_to:
+                reply_message = {
+                    "command_id": str(command_id),
+                    "correlation_id": str(command.correlation_id)
+                    if command.correlation_id
+                    else None,
+                    "outcome": ReplyOutcome.SUCCESS.value,
+                    "result": result,
+                }
+                self._pgmq.send(command.reply_to, reply_message, conn=conn)
+
+        logger.info(f"Completed command {domain}.{command.command_type} (command_id={command_id})")
+
+        # Invoke batch completion callback - outside transaction
+        if is_batch_complete and received.metadata.batch_id is not None:
+            invoke_sync_batch_callback(domain, received.metadata.batch_id, self._batch_repo)
+
+    def _fail(
+        self,
+        received: ReceivedCommand,
+        error: TransientCommandError | Exception,
+        is_transient: bool = True,
+    ) -> None:
+        """Record a command failure and schedule retry if applicable.
+
+        Args:
+            received: The received command that failed
+            error: The error that occurred
+            is_transient: Whether this is a transient (retryable) error
+        """
+        command = received.command
+        command_id = command.command_id
+        domain = command.domain
+        attempt = received.context.attempt
+
+        # Extract error details
+        if isinstance(error, TransientCommandError):
+            error_type = "TRANSIENT"
+            error_code = error.code
+            error_msg = error.error_message
+        elif isinstance(error, PermanentCommandError):
+            error_type = "PERMANENT"
+            error_code = error.code
+            error_msg = error.error_message
+        else:
+            error_type = "TRANSIENT"
+            error_code = type(error).__name__
+            error_msg = str(error)
+
+        # Check if retries are exhausted for transient errors
+        if is_transient and not self._retry_policy.should_retry(attempt):
+            self._fail_exhausted(received, error_type, error_code, error_msg)
+            return
+
+        with self._pool.connection() as conn, conn.transaction():
+            # Use stored procedure to fail command
+            self._command_repo.sp_fail_command(
+                domain,
+                command_id,
+                error_type,
+                error_code,
+                error_msg,
+                attempt,
+                received.metadata.max_attempts,
+                received.msg_id,
+                conn=conn,
+            )
+
+            # Apply backoff by extending visibility timeout
+            if is_transient:
+                backoff = self._retry_policy.get_backoff(attempt)
+                self._pgmq.set_vt(self._queue_name, received.msg_id, backoff, conn)
+
+        if is_transient:
+            delay = self._retry_policy.get_backoff(attempt)
+            logger.info(
+                f"Transient failure for {domain}.{command.command_type} "
+                f"(command_id={command_id}, attempt={attempt}, backoff={delay}s): "
+                f"[{error_code}] {error_msg}"
+            )
+        else:
+            logger.warning(
+                f"Failure for {domain}.{command.command_type} "
+                f"(command_id={command_id}, attempt={attempt}): "
+                f"[{error_code}] {error_msg}"
+            )
+
+    def _fail_permanent(
+        self,
+        received: ReceivedCommand,
+        error: PermanentCommandError,
+    ) -> None:
+        """Handle a permanent failure by moving command to troubleshooting queue.
+
+        Args:
+            received: The received command that failed
+            error: The permanent error that occurred
+        """
+        command = received.command
+        command_id = command.command_id
+        domain = command.domain
+
+        with self._pool.connection() as conn, conn.transaction():
+            # Archive message
+            self._pgmq.archive(self._queue_name, received.msg_id, conn)
+
+            # Use stored procedure to finish command
+            self._command_repo.sp_finish_command(
+                domain,
+                command_id,
+                CommandStatus.IN_TROUBLESHOOTING_QUEUE,
+                event_type="MOVED_TO_TSQ",
+                error_type="PERMANENT",
+                error_code=error.code,
+                error_msg=error.error_message,
+                details={
+                    "msg_id": received.msg_id,
+                    "attempt": received.context.attempt,
+                    "error_code": error.code,
+                    "error_msg": error.error_message,
+                    "error_details": error.details,
+                },
+                batch_id=received.metadata.batch_id,
+                conn=conn,
+            )
+
+        logger.warning(
+            f"Permanent failure for {domain}.{command.command_type} "
+            f"(command_id={command_id}), moved to troubleshooting queue: "
+            f"[{error.code}] {error.error_message}"
+        )
+
+    def _fail_exhausted(
+        self,
+        received: ReceivedCommand,
+        error_type: str,
+        error_code: str,
+        error_msg: str,
+    ) -> None:
+        """Handle retry exhaustion by moving command to troubleshooting queue.
+
+        Args:
+            received: The received command that exhausted retries
+            error_type: Type of the error
+            error_code: Error code from the exception
+            error_msg: Error message from the exception
+        """
+        command = received.command
+        command_id = command.command_id
+        domain = command.domain
+        attempt = received.context.attempt
+
+        with self._pool.connection() as conn, conn.transaction():
+            # Archive message
+            self._pgmq.archive(self._queue_name, received.msg_id, conn)
+
+            # Use stored procedure to finish command
+            self._command_repo.sp_finish_command(
+                domain,
+                command_id,
+                CommandStatus.IN_TROUBLESHOOTING_QUEUE,
+                event_type="MOVED_TO_TSQ",
+                error_type=error_type,
+                error_code=error_code,
+                error_msg=error_msg,
+                details={
+                    "msg_id": received.msg_id,
+                    "attempt": attempt,
+                    "max_attempts": received.metadata.max_attempts,
+                    "reason": "EXHAUSTED",
+                    "error_type": error_type,
+                    "error_code": error_code,
+                    "error_msg": error_msg,
+                },
+                batch_id=received.metadata.batch_id,
+                conn=conn,
+            )
+
+        logger.warning(
+            f"Retry exhausted for {domain}.{command.command_type} "
+            f"(command_id={command_id}, attempt={attempt}/{received.metadata.max_attempts}), "
+            f"moved to troubleshooting queue: [{error_code}] {error_msg}"
+        )
+
+    def _cleanup_completed(self) -> None:
+        """Remove completed futures from in-flight tracking."""
+        with self._in_flight_lock:
+            completed = [msg_id for msg_id, (future, _) in self._in_flight.items() if future.done()]
+            for msg_id in completed:
+                del self._in_flight[msg_id]
+
+    def _check_stuck_threads(self) -> None:
+        """Check for threads that have been running too long."""
+        now = time.monotonic()
+        stuck_threshold = self._visibility_timeout + 5.0
+
+        with self._in_flight_lock:
+            for msg_id, (future, start_time) in list(self._in_flight.items()):
+                elapsed = now - start_time
+                if elapsed > stuck_threshold and not future.done():
+                    logger.error(f"Thread stuck for {elapsed:.1f}s processing msg_id={msg_id}")
+                    self._health.record_stuck_thread()
+                    # Note: We don't cancel the future as it may complete eventually
+                    # The message will become visible again after visibility timeout
+
+    def _wait_for_slot(self, timeout: float = 5.0) -> None:
+        """Wait for at least one in-flight task to complete.
+
+        Args:
+            timeout: Maximum time to wait in seconds
+        """
+        with self._in_flight_lock:
+            futures = [f for f, _ in self._in_flight.values()]
+
+        if not futures:
+            return
+
+        # Wait for any one task to complete
+        wait(futures, timeout=timeout, return_when="FIRST_COMPLETED")
+
+    def _drain_in_flight(self, timeout: float = 30.0) -> None:
+        """Wait for all in-flight tasks to complete.
+
+        Args:
+            timeout: Maximum time to wait in seconds
+        """
+        with self._in_flight_lock:
+            futures = [f for f, _ in self._in_flight.values()]
+
+        if not futures:
+            return
+
+        logger.info(f"Draining {len(futures)} in-flight commands...")
+        _done, not_done = wait(futures, timeout=timeout)
+
+        if not_done:
+            logger.warning(
+                f"Timeout draining in-flight commands, {len(not_done)} commands may be redelivered"
+            )
+
+    def stop(self, timeout: float | None = None) -> None:
+        """Stop the worker gracefully.
+
+        Signals the worker to stop receiving new commands and waits for
+        in-flight commands to complete (or timeout).
+
+        Args:
+            timeout: Maximum seconds to wait for in-flight commands.
+                     If None, uses default drain timeout.
+        """
+        logger.info(f"Stopping sync worker for {self._domain}...")
+        self._stop_event.set()
+
+        if self.in_flight_count > 0:
+            logger.info(f"Waiting for {self.in_flight_count} in-flight commands...")
+            self._drain_in_flight(timeout=timeout or 30.0)

--- a/tests/unit/sync/test_sync_worker.py
+++ b/tests/unit/sync/test_sync_worker.py
@@ -1,0 +1,716 @@
+"""Unit tests for commandbus.sync.worker module."""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from commandbus.exceptions import (
+    HandlerNotFoundError,
+    PermanentCommandError,
+    TransientCommandError,
+)
+from commandbus.handler import HandlerRegistry
+from commandbus.models import (
+    Command,
+    CommandMetadata,
+    HandlerContext,
+)
+from commandbus.sync.health import HealthState
+from commandbus.sync.worker import (
+    ReceivedCommand,
+    SyncWorker,
+    _make_queue_name,
+)
+
+
+class TestMakeQueueName:
+    """Tests for _make_queue_name helper function."""
+
+    def test_default_suffix(self) -> None:
+        """Should use 'commands' as default suffix."""
+        result = _make_queue_name("payments")
+        assert result == "payments__commands"
+
+    def test_custom_suffix(self) -> None:
+        """Should allow custom suffix."""
+        result = _make_queue_name("payments", "replies")
+        assert result == "payments__replies"
+
+
+class TestReceivedCommand:
+    """Tests for ReceivedCommand dataclass."""
+
+    def test_dataclass_fields(self) -> None:
+        """Should store command, context, msg_id, and metadata."""
+        command = Command(
+            domain="payments",
+            command_type="DebitAccount",
+            command_id=uuid4(),
+            data={"amount": 100},
+        )
+        context = HandlerContext(
+            command=command,
+            attempt=1,
+            max_attempts=3,
+            msg_id=42,
+        )
+        metadata = MagicMock(spec=CommandMetadata)
+
+        received = ReceivedCommand(
+            command=command,
+            context=context,
+            msg_id=42,
+            metadata=metadata,
+        )
+
+        assert received.command is command
+        assert received.context is context
+        assert received.msg_id == 42
+        assert received.metadata is metadata
+
+
+class TestSyncWorkerInit:
+    """Tests for SyncWorker initialization."""
+
+    def test_init_with_defaults(self) -> None:
+        """Should initialize with default values."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments")
+
+        assert worker._pool is mock_pool
+        assert worker._domain == "payments"
+        assert worker._registry is None
+        assert worker._visibility_timeout == 30
+        assert worker._statement_timeout == 25000
+        assert worker._queue_name == "payments__commands"
+        assert worker._concurrency == 1
+        assert worker._stop_event is not None
+        assert worker._health is not None
+
+    def test_init_with_custom_values(self) -> None:
+        """Should allow custom configuration."""
+        mock_pool = MagicMock()
+        mock_registry = MagicMock()
+        mock_policy = MagicMock()
+
+        worker = SyncWorker(
+            mock_pool,
+            domain="orders",
+            registry=mock_registry,
+            visibility_timeout=60,
+            retry_policy=mock_policy,
+            statement_timeout=30000,
+        )
+
+        assert worker._domain == "orders"
+        assert worker._registry is mock_registry
+        assert worker._visibility_timeout == 60
+        assert worker._retry_policy is mock_policy
+        assert worker._statement_timeout == 30000
+
+    def test_init_creates_sync_components(self) -> None:
+        """Should create sync PGMQ client and repositories."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments")
+
+        assert worker._pgmq is not None
+        assert worker._command_repo is not None
+        assert worker._batch_repo is not None
+        assert worker._audit_logger is not None
+
+
+class TestSyncWorkerProperties:
+    """Tests for SyncWorker properties."""
+
+    def test_domain_property(self) -> None:
+        """Should return the domain."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments")
+
+        assert worker.domain == "payments"
+
+    def test_queue_name_property(self) -> None:
+        """Should return the queue name."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments")
+
+        assert worker.queue_name == "payments__commands"
+
+    def test_health_status_property(self) -> None:
+        """Should return the health status tracker."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments")
+
+        assert worker.health_status is worker._health
+        assert worker.health_status.state == HealthState.HEALTHY
+
+    def test_is_running_false_initially(self) -> None:
+        """Should return False when not running."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments")
+
+        assert worker.is_running is False
+
+    def test_in_flight_count_zero_initially(self) -> None:
+        """Should return 0 when nothing in flight."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments")
+
+        assert worker.in_flight_count == 0
+
+
+class TestSyncWorkerRun:
+    """Tests for SyncWorker.run method."""
+
+    def test_run_without_registry_raises(self) -> None:
+        """Should raise RuntimeError if no registry configured."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments")
+
+        with pytest.raises(RuntimeError, match="Cannot run worker without a handler registry"):
+            worker.run()
+
+    def test_run_creates_thread_pool(self) -> None:
+        """Should create ThreadPoolExecutor with specified concurrency."""
+        mock_pool = MagicMock()
+        mock_registry = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments", registry=mock_registry)
+
+        # Patch _run_loop to avoid blocking
+        with patch.object(worker, "_run_loop"):
+            worker.run(concurrency=8, poll_interval=0.1)
+
+        assert worker._concurrency == 8
+
+    def test_run_clears_stop_event(self) -> None:
+        """Should clear stop event at start."""
+        mock_pool = MagicMock()
+        mock_registry = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments", registry=mock_registry)
+
+        worker._stop_event.set()
+
+        # Run in a way that stops quickly
+        with patch.object(worker, "_run_loop"):
+            worker.run()
+
+        # _run_loop was called after clearing stop event
+        assert worker._executor is None  # shutdown after run
+
+
+class TestSyncWorkerStop:
+    """Tests for SyncWorker.stop method."""
+
+    def test_stop_sets_event(self) -> None:
+        """Should set the stop event."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments")
+
+        assert not worker._stop_event.is_set()
+
+        worker.stop()
+
+        assert worker._stop_event.is_set()
+
+    def test_stop_waits_for_in_flight(self) -> None:
+        """Should wait for in-flight commands when stopping."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments")
+
+        # Simulate in-flight work
+        mock_future = MagicMock()
+        mock_future.done.return_value = True
+        worker._in_flight[1] = (mock_future, 0.0)
+
+        with patch.object(worker, "_drain_in_flight") as mock_drain:
+            worker.stop(timeout=10.0)
+
+        mock_drain.assert_called_once_with(timeout=10.0)
+
+
+class TestSyncWorkerReceive:
+    """Tests for SyncWorker._receive method."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.mock_pool = MagicMock()
+        self.mock_conn = MagicMock()
+        self.mock_pool.connection.return_value.__enter__ = MagicMock(return_value=self.mock_conn)
+        self.mock_pool.connection.return_value.__exit__ = MagicMock(return_value=None)
+
+        self.worker = SyncWorker(self.mock_pool, domain="payments")
+
+    def test_receive_sets_statement_timeout(self) -> None:
+        """Should set statement_timeout on connection."""
+        self.worker._pgmq.read = MagicMock(return_value=[])
+
+        self.worker._receive(batch_size=1)
+
+        self.mock_conn.execute.assert_called_once_with("SET statement_timeout = 25000")
+
+    def test_receive_with_custom_visibility_timeout(self) -> None:
+        """Should use provided visibility_timeout."""
+        self.worker._pgmq.read = MagicMock(return_value=[])
+
+        self.worker._receive(batch_size=1, visibility_timeout=120)
+
+        self.worker._pgmq.read.assert_called_once_with(
+            "payments__commands",
+            visibility_timeout=120,
+            batch_size=1,
+            conn=self.mock_conn,
+        )
+
+    def test_receive_returns_empty_list_when_no_messages(self) -> None:
+        """Should return empty list when no messages available."""
+        self.worker._pgmq.read = MagicMock(return_value=[])
+
+        result = self.worker._receive(batch_size=5)
+
+        assert result == []
+
+
+class TestSyncWorkerProcessMessage:
+    """Tests for SyncWorker._process_message method."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.mock_pool = MagicMock()
+        self.mock_conn = MagicMock()
+
+        self.worker = SyncWorker(self.mock_pool, domain="payments")
+        self.worker._pgmq = MagicMock()
+        self.worker._command_repo = MagicMock()
+
+    def test_process_message_missing_command_id_archives(self) -> None:
+        """Should archive message if command_id is missing."""
+        message = {"domain": "payments", "command_type": "Test"}
+
+        result = self.worker._process_message(1, message, self.mock_conn)
+
+        assert result is None
+        self.worker._pgmq.archive.assert_called_once_with("payments__commands", 1, self.mock_conn)
+
+    def test_process_message_no_metadata_archives(self) -> None:
+        """Should archive message if no metadata found."""
+        command_id = uuid4()
+        message = {"command_id": str(command_id), "domain": "payments"}
+        self.worker._command_repo.sp_receive_command = MagicMock(return_value=None)
+
+        result = self.worker._process_message(1, message, self.mock_conn)
+
+        assert result is None
+        self.worker._pgmq.archive.assert_called_once()
+
+    def test_process_message_returns_received_command(self) -> None:
+        """Should return ReceivedCommand for valid message."""
+        command_id = uuid4()
+        message = {
+            "command_id": str(command_id),
+            "domain": "payments",
+            "command_type": "DebitAccount",
+            "data": {"amount": 100},
+        }
+
+        mock_metadata = MagicMock(spec=CommandMetadata)
+        mock_metadata.command_type = "DebitAccount"
+        mock_metadata.created_at = datetime.now(UTC)
+        mock_metadata.max_attempts = 3
+
+        self.worker._command_repo.sp_receive_command = MagicMock(return_value=(mock_metadata, 1))
+
+        result = self.worker._process_message(42, message, self.mock_conn)
+
+        assert result is not None
+        assert isinstance(result, ReceivedCommand)
+        assert result.command.command_id == command_id
+        assert result.context.attempt == 1
+        assert result.msg_id == 42
+        assert result.metadata is mock_metadata
+
+
+class TestSyncWorkerProcessCommand:
+    """Tests for SyncWorker._process_command method."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.mock_pool = MagicMock()
+        self.mock_conn = MagicMock()
+        self.mock_registry = MagicMock()
+
+        # Setup connection context manager
+        self.mock_pool.connection.return_value.__enter__ = MagicMock(return_value=self.mock_conn)
+        self.mock_pool.connection.return_value.__exit__ = MagicMock(return_value=None)
+        self.mock_conn.transaction.return_value.__enter__ = MagicMock()
+        self.mock_conn.transaction.return_value.__exit__ = MagicMock(return_value=None)
+
+        self.worker = SyncWorker(self.mock_pool, domain="payments", registry=self.mock_registry)
+        self.worker._pgmq = MagicMock()
+        self.worker._command_repo = MagicMock()
+
+    def _make_received_command(self) -> ReceivedCommand:
+        """Create a test ReceivedCommand."""
+        command = Command(
+            domain="payments",
+            command_type="DebitAccount",
+            command_id=uuid4(),
+            data={"amount": 100},
+        )
+        context = HandlerContext(
+            command=command,
+            attempt=1,
+            max_attempts=3,
+            msg_id=42,
+        )
+        metadata = MagicMock(spec=CommandMetadata)
+        metadata.batch_id = None
+        metadata.max_attempts = 3
+
+        return ReceivedCommand(
+            command=command,
+            context=context,
+            msg_id=42,
+            metadata=metadata,
+        )
+
+    def test_process_command_success(self) -> None:
+        """Should dispatch to handler and complete on success."""
+        received = self._make_received_command()
+        self.mock_registry.dispatch_sync = MagicMock(return_value={"ok": True})
+        self.worker._command_repo.sp_finish_command = MagicMock(return_value=False)
+
+        self.worker._process_command(received)
+
+        self.mock_registry.dispatch_sync.assert_called_once()
+        assert self.worker._health.state == HealthState.HEALTHY
+
+    def test_process_command_transient_error(self) -> None:
+        """Should handle transient error with retry."""
+        received = self._make_received_command()
+        self.mock_registry.dispatch_sync = MagicMock(
+            side_effect=TransientCommandError(code="TIMEOUT", message="Timed out")
+        )
+        self.worker._command_repo.sp_fail_command = MagicMock()
+
+        self.worker._process_command(received)
+
+        self.worker._command_repo.sp_fail_command.assert_called_once()
+
+    def test_process_command_permanent_error(self) -> None:
+        """Should handle permanent error by moving to TSQ."""
+        received = self._make_received_command()
+        self.mock_registry.dispatch_sync = MagicMock(
+            side_effect=PermanentCommandError(code="INVALID", message="Invalid data")
+        )
+        self.worker._command_repo.sp_finish_command = MagicMock(return_value=False)
+
+        self.worker._process_command(received)
+
+        # Should archive and finish with IN_TROUBLESHOOTING_QUEUE status
+        self.worker._pgmq.archive.assert_called_once()
+
+    def test_process_command_removes_from_in_flight(self) -> None:
+        """Should remove from in-flight tracking on completion."""
+        received = self._make_received_command()
+        self.mock_registry.dispatch_sync = MagicMock(return_value=None)
+        self.worker._command_repo.sp_finish_command = MagicMock(return_value=False)
+
+        # Add to in-flight
+        self.worker._in_flight[received.msg_id] = (MagicMock(), 0.0)
+
+        self.worker._process_command(received)
+
+        assert received.msg_id not in self.worker._in_flight
+
+
+class TestSyncWorkerComplete:
+    """Tests for SyncWorker._complete method."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.mock_pool = MagicMock()
+        self.mock_conn = MagicMock()
+
+        # Setup connection context managers
+        self.mock_pool.connection.return_value.__enter__ = MagicMock(return_value=self.mock_conn)
+        self.mock_pool.connection.return_value.__exit__ = MagicMock(return_value=None)
+        self.mock_conn.transaction.return_value.__enter__ = MagicMock()
+        self.mock_conn.transaction.return_value.__exit__ = MagicMock(return_value=None)
+
+        self.worker = SyncWorker(self.mock_pool, domain="payments")
+        self.worker._pgmq = MagicMock()
+        self.worker._command_repo = MagicMock()
+
+    def test_complete_deletes_message(self) -> None:
+        """Should delete message from queue."""
+        command = Command(
+            domain="payments",
+            command_type="DebitAccount",
+            command_id=uuid4(),
+            data={"amount": 100},
+        )
+        context = HandlerContext(command=command, attempt=1, max_attempts=3, msg_id=42)
+        metadata = MagicMock()
+        metadata.batch_id = None
+
+        received = ReceivedCommand(command=command, context=context, msg_id=42, metadata=metadata)
+        self.worker._command_repo.sp_finish_command = MagicMock(return_value=False)
+
+        self.worker._complete(received)
+
+        self.worker._pgmq.delete.assert_called_once()
+
+    def test_complete_sends_reply_when_configured(self) -> None:
+        """Should send reply to reply_to queue."""
+        command = Command(
+            domain="payments",
+            command_type="DebitAccount",
+            command_id=uuid4(),
+            data={"amount": 100},
+            reply_to="payments__replies",
+        )
+        context = HandlerContext(command=command, attempt=1, max_attempts=3, msg_id=42)
+        metadata = MagicMock()
+        metadata.batch_id = None
+
+        received = ReceivedCommand(command=command, context=context, msg_id=42, metadata=metadata)
+        self.worker._command_repo.sp_finish_command = MagicMock(return_value=False)
+
+        self.worker._complete(received, result={"success": True})
+
+        # Should send reply
+        send_calls = self.worker._pgmq.send.call_args_list
+        assert len(send_calls) == 1
+        assert send_calls[0][0][0] == "payments__replies"
+
+
+class TestSyncWorkerFail:
+    """Tests for SyncWorker._fail method."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.mock_pool = MagicMock()
+        self.mock_conn = MagicMock()
+
+        # Setup connection context managers
+        self.mock_pool.connection.return_value.__enter__ = MagicMock(return_value=self.mock_conn)
+        self.mock_pool.connection.return_value.__exit__ = MagicMock(return_value=None)
+        self.mock_conn.transaction.return_value.__enter__ = MagicMock()
+        self.mock_conn.transaction.return_value.__exit__ = MagicMock(return_value=None)
+
+        self.worker = SyncWorker(self.mock_pool, domain="payments")
+        self.worker._pgmq = MagicMock()
+        self.worker._command_repo = MagicMock()
+
+    def _make_received_command(self, attempt: int = 1) -> ReceivedCommand:
+        """Create a test ReceivedCommand."""
+        command = Command(
+            domain="payments",
+            command_type="DebitAccount",
+            command_id=uuid4(),
+            data={"amount": 100},
+        )
+        context = HandlerContext(
+            command=command,
+            attempt=attempt,
+            max_attempts=3,
+            msg_id=42,
+        )
+        metadata = MagicMock(spec=CommandMetadata)
+        metadata.batch_id = None
+        metadata.max_attempts = 3
+
+        return ReceivedCommand(
+            command=command,
+            context=context,
+            msg_id=42,
+            metadata=metadata,
+        )
+
+    def test_fail_transient_applies_backoff(self) -> None:
+        """Should apply backoff via set_vt for transient errors."""
+        received = self._make_received_command(attempt=1)
+        error = TransientCommandError(code="TIMEOUT", message="Timed out")
+
+        self.worker._fail(received, error, is_transient=True)
+
+        # Should call sp_fail_command and set_vt for backoff
+        self.worker._command_repo.sp_fail_command.assert_called_once()
+        self.worker._pgmq.set_vt.assert_called_once()
+
+    def test_fail_exhausted_moves_to_tsq(self) -> None:
+        """Should move to TSQ when retries exhausted."""
+        # Create received at max attempts
+        received = self._make_received_command(attempt=3)
+        error = TransientCommandError(code="TIMEOUT", message="Timed out")
+
+        # Mock retry policy to say no more retries
+        self.worker._retry_policy = MagicMock()
+        self.worker._retry_policy.should_retry = MagicMock(return_value=False)
+
+        self.worker._fail(received, error, is_transient=True)
+
+        # Should archive (move to TSQ)
+        self.worker._pgmq.archive.assert_called_once()
+
+
+class TestSyncWorkerHealthTracking:
+    """Tests for health status tracking in SyncWorker."""
+
+    def test_check_stuck_threads(self) -> None:
+        """Should detect stuck threads based on timeout."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments", visibility_timeout=1)
+
+        # Add an old in-flight task
+        mock_future = MagicMock()
+        mock_future.done.return_value = False
+        worker._in_flight[1] = (mock_future, 0.0)  # Started at time 0
+
+        # Check with current time way past threshold
+        with patch("commandbus.sync.worker.time.monotonic", return_value=100.0):
+            worker._check_stuck_threads()
+
+        assert worker._health.stuck_threads == 1
+
+    def test_cleanup_completed_removes_done_futures(self) -> None:
+        """Should remove completed futures from in-flight."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments")
+
+        # Add a completed future
+        done_future = MagicMock()
+        done_future.done.return_value = True
+        worker._in_flight[1] = (done_future, 0.0)
+
+        # Add a not-done future
+        pending_future = MagicMock()
+        pending_future.done.return_value = False
+        worker._in_flight[2] = (pending_future, 0.0)
+
+        worker._cleanup_completed()
+
+        assert 1 not in worker._in_flight
+        assert 2 in worker._in_flight
+
+
+class TestSyncWorkerDrain:
+    """Tests for SyncWorker._drain_in_flight method."""
+
+    def test_drain_empty_returns_immediately(self) -> None:
+        """Should return immediately when no in-flight tasks."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments")
+
+        # Should not raise and return quickly
+        worker._drain_in_flight(timeout=1.0)
+
+    def test_drain_waits_for_futures(self) -> None:
+        """Should wait for all futures to complete."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments")
+
+        mock_future = MagicMock()
+        worker._in_flight[1] = (mock_future, 0.0)
+
+        with patch("commandbus.sync.worker.wait") as mock_wait:
+            mock_wait.return_value = ({mock_future}, set())
+            worker._drain_in_flight(timeout=5.0)
+
+        mock_wait.assert_called_once()
+
+
+class TestSyncWorkerWaitForSlot:
+    """Tests for SyncWorker._wait_for_slot method."""
+
+    def test_wait_for_slot_empty_returns(self) -> None:
+        """Should return immediately when no in-flight tasks."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments")
+
+        # Should not block
+        worker._wait_for_slot(timeout=0.1)
+
+    def test_wait_for_slot_waits_for_completion(self) -> None:
+        """Should wait for any task to complete."""
+        mock_pool = MagicMock()
+        worker = SyncWorker(mock_pool, domain="payments")
+
+        mock_future = MagicMock()
+        worker._in_flight[1] = (mock_future, 0.0)
+
+        with patch("commandbus.sync.worker.wait") as mock_wait:
+            mock_wait.return_value = ({mock_future}, set())
+            worker._wait_for_slot(timeout=1.0)
+
+        mock_wait.assert_called_once()
+        _args, kwargs = mock_wait.call_args
+        assert kwargs.get("return_when") == "FIRST_COMPLETED"
+
+
+class TestSyncHandlerRegistration:
+    """Tests for sync handler registration in HandlerRegistry."""
+
+    def test_sync_handler_decorator(self) -> None:
+        """Should register sync handler via decorator."""
+        registry = HandlerRegistry()
+
+        @registry.sync_handler("payments", "DebitAccount")
+        def handle_debit(command: Command, context: HandlerContext) -> dict:
+            return {"processed": True}
+
+        assert registry.has_sync_handler("payments", "DebitAccount")
+
+    def test_dispatch_sync(self) -> None:
+        """Should dispatch to registered sync handler."""
+        registry = HandlerRegistry()
+        calls = []
+
+        @registry.sync_handler("payments", "DebitAccount")
+        def handle_debit(command: Command, context: HandlerContext) -> dict:
+            calls.append(command.command_id)
+            return {"processed": True}
+
+        command = Command(
+            domain="payments",
+            command_type="DebitAccount",
+            command_id=uuid4(),
+            data={"amount": 100},
+        )
+        context = HandlerContext(command=command, attempt=1, max_attempts=3, msg_id=1)
+
+        result = registry.dispatch_sync(command, context)
+
+        assert result == {"processed": True}
+        assert len(calls) == 1
+
+    def test_dispatch_sync_not_found(self) -> None:
+        """Should raise HandlerNotFoundError for missing handler."""
+        registry = HandlerRegistry()
+
+        command = Command(
+            domain="payments",
+            command_type="Unknown",
+            command_id=uuid4(),
+            data={},
+        )
+        context = HandlerContext(command=command, attempt=1, max_attempts=3, msg_id=1)
+
+        with pytest.raises(HandlerNotFoundError):
+            registry.dispatch_sync(command, context)
+
+    def test_clear_clears_sync_handlers(self) -> None:
+        """Should clear sync handlers on clear()."""
+        registry = HandlerRegistry()
+
+        @registry.sync_handler("payments", "DebitAccount")
+        def handle_debit(command: Command, context: HandlerContext) -> dict:
+            return {}
+
+        assert registry.has_sync_handler("payments", "DebitAccount")
+
+        registry.clear()
+
+        assert not registry.has_sync_handler("payments", "DebitAccount")

--- a/tests/unit/sync/test_worker.py
+++ b/tests/unit/sync/test_worker.py
@@ -1,3 +1,10 @@
+"""Tests for sync wrapper components (will be replaced by native sync).
+
+The SyncWorker tests have been moved to test_sync_worker.py which tests
+the native implementation. This file retains tests for wrapper components
+that haven't been replaced yet.
+"""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
@@ -6,7 +13,6 @@ import pytest
 
 from commandbus.sync.process import SyncProcessReplyRouter
 from commandbus.sync.runtime import SyncRuntime
-from commandbus.sync.worker import SyncWorker
 
 
 @pytest.fixture()
@@ -14,56 +20,6 @@ def runtime() -> SyncRuntime:
     rt = SyncRuntime()
     yield rt
     rt.shutdown()
-
-
-def test_sync_worker_runs_blocking(runtime: SyncRuntime) -> None:
-    worker = MagicMock()
-    worker.run = AsyncMock(return_value=None)
-    worker.stop = AsyncMock(return_value=None)
-
-    sync_worker = SyncWorker(worker=worker, runtime=runtime, thread_pool_size=1)
-    sync_worker.run(concurrency=2, poll_interval=0.5, use_notify=False)
-    worker.run.assert_awaited_once_with(concurrency=2, poll_interval=0.5, use_notify=False)
-
-    sync_worker.stop()
-    worker.stop.assert_awaited_once()
-    sync_worker.shutdown()
-
-
-def test_sync_worker_non_blocking(runtime: SyncRuntime) -> None:
-    worker = MagicMock()
-    worker.run = AsyncMock(return_value=None)
-    worker.stop = AsyncMock(return_value=None)
-    sync_worker = SyncWorker(worker=worker, runtime=runtime, thread_pool_size=1)
-
-    sync_worker.run(block=False)
-    sync_worker.stop()
-    sync_worker.shutdown()
-
-
-def test_sync_worker_prevents_double_run(runtime: SyncRuntime) -> None:
-    worker = MagicMock()
-    worker.run = AsyncMock(return_value=None)
-    worker.stop = AsyncMock(return_value=None)
-    sync_worker = SyncWorker(worker=worker, runtime=runtime, thread_pool_size=1)
-
-    sync_worker.run(block=False)
-    with pytest.raises(RuntimeError):
-        sync_worker.run(block=False)
-
-    sync_worker.stop()
-    sync_worker.shutdown()
-
-
-def test_sync_worker_exposes_domain(runtime: SyncRuntime) -> None:
-    worker = MagicMock()
-    worker.run = AsyncMock(return_value=None)
-    worker.stop = AsyncMock(return_value=None)
-    worker.domain = "reporting"
-
-    sync_worker = SyncWorker(worker=worker, runtime=runtime, thread_pool_size=1)
-    assert sync_worker.domain == "reporting"
-    sync_worker.shutdown()
 
 
 def test_sync_process_router_exposes_metadata(runtime: SyncRuntime) -> None:


### PR DESCRIPTION
## Summary

- Implement native `SyncWorker` using `ThreadPoolExecutor` for concurrent command processing
- Add sync handler registration (`register_sync`, `sync_handler` decorator) and `dispatch_sync` to `HandlerRegistry`
- Support statement timeout configuration per connection (`SET statement_timeout`)
- Implement stuck thread detection based on visibility timeout threshold
- Integrate with `HealthStatus` for monitoring worker health
- Add graceful shutdown with in-flight task draining

This replaces the wrapper-based `SyncWorker` that wrapped the async `Worker` with `SyncRuntime.run()`. The native implementation eliminates async overhead and provides predictable connection usage.

## Test plan

- [x] Unit tests for `SyncWorker` (40 tests in `test_sync_worker.py`)
- [x] Unit tests for sync handler registration in `HandlerRegistry`
- [x] All existing unit and integration tests pass
- [x] Coverage remains above 80%

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)