### PR TITLE
feat: Add timeout hierarchy and validation (S086)

### DIFF
--- a/src/commandbus/sync/__init__.py
+++ b/src/commandbus/sync/__init__.py
@@ -5,6 +5,14 @@ from commandbus.sync.config import configure, get_default_runtime, get_thread_po
 from commandbus.sync.health import HealthState, HealthStatus
 from commandbus.sync.process import SyncProcessReplyRouter
 from commandbus.sync.runtime import SyncRuntime
+from commandbus.sync.timeouts import (
+    TimeoutConfig,
+    create_pool_with_timeout,
+    is_pool_timeout,
+    is_query_cancelled,
+    is_timeout_error,
+    validate_timeouts,
+)
 from commandbus.sync.tsq import SyncTroubleshootingQueue
 from commandbus.sync.watchdog import WorkerWatchdog
 from commandbus.sync.worker import SyncWorker
@@ -17,8 +25,14 @@ __all__ = [
     "SyncRuntime",
     "SyncTroubleshootingQueue",
     "SyncWorker",
+    "TimeoutConfig",
     "WorkerWatchdog",
     "configure",
+    "create_pool_with_timeout",
     "get_default_runtime",
     "get_thread_pool_size",
+    "is_pool_timeout",
+    "is_query_cancelled",
+    "is_timeout_error",
+    "validate_timeouts",
 ]

--- a/src/commandbus/sync/timeouts.py
+++ b/src/commandbus/sync/timeouts.py
@@ -1,0 +1,211 @@
+"""Timeout configuration and validation for sync workers.
+
+This module provides timeout constants, configuration helpers, and validation
+for the multi-layer timeout hierarchy used in sync workers and routers.
+
+Timeout Hierarchy:
+    Layer 1: PostgreSQL statement_timeout (25s default)
+        - Kills query on server, frees database resources
+        - Should be less than visibility_timeout
+
+    Layer 2: Connection pool timeout (30s default)
+        - Fail-fast on pool exhaustion
+        - Raises PoolTimeout if no connection available
+
+    Layer 3: PGMQ visibility_timeout (30s default)
+        - Message reappears if not deleted within timeout
+        - Allows for automatic retry on failure
+
+    Layer 4: Thread stuck threshold (visibility_timeout + 5s)
+        - Worker detects threads running longer than expected
+        - Records stuck thread in health status
+
+    Layer 5: Worker watchdog (configurable interval)
+        - Monitors overall worker health
+        - Can trigger recovery on CRITICAL state
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from psycopg import errors as psycopg_errors
+from psycopg_pool import ConnectionPool, PoolTimeout
+
+logger = logging.getLogger(__name__)
+
+
+# Default timeout values
+DEFAULT_STATEMENT_TIMEOUT_MS = 25000  # 25 seconds
+DEFAULT_VISIBILITY_TIMEOUT_S = 30  # 30 seconds
+DEFAULT_POOL_TIMEOUT_S = 30.0  # 30 seconds
+DEFAULT_WATCHDOG_INTERVAL_S = 10.0  # 10 seconds
+STUCK_THREAD_BUFFER_S = 5.0  # Added to visibility_timeout for stuck detection
+
+
+@dataclass(frozen=True)
+class TimeoutConfig:
+    """Timeout configuration for sync workers and routers.
+
+    All timeouts are validated to ensure proper ordering:
+    - statement_timeout (ms) / 1000 < visibility_timeout (s)
+    - This ensures queries are cancelled before messages become visible again
+
+    Example:
+        config = TimeoutConfig(
+            statement_timeout_ms=25000,  # 25s
+            visibility_timeout_s=30,     # 30s
+            pool_timeout_s=30.0,         # 30s
+        )
+        config.validate()  # Raises ValueError if invalid
+
+        # Use in worker
+        worker = SyncWorker(
+            pool=pool,
+            domain="payments",
+            registry=registry,
+            statement_timeout=config.statement_timeout_ms,
+            visibility_timeout=config.visibility_timeout_s,
+        )
+    """
+
+    statement_timeout_ms: int = DEFAULT_STATEMENT_TIMEOUT_MS
+    visibility_timeout_s: int = DEFAULT_VISIBILITY_TIMEOUT_S
+    pool_timeout_s: float = DEFAULT_POOL_TIMEOUT_S
+    watchdog_interval_s: float = DEFAULT_WATCHDOG_INTERVAL_S
+
+    @property
+    def statement_timeout_s(self) -> float:
+        """Get statement timeout in seconds."""
+        return self.statement_timeout_ms / 1000.0
+
+    @property
+    def stuck_threshold_s(self) -> float:
+        """Get stuck thread detection threshold in seconds."""
+        return self.visibility_timeout_s + STUCK_THREAD_BUFFER_S
+
+    def validate(self) -> None:
+        """Validate timeout configuration.
+
+        Raises:
+            ValueError: If timeouts are not properly ordered or invalid
+        """
+        # All timeouts must be positive (check this first)
+        if self.statement_timeout_ms <= 0:
+            raise ValueError(f"statement_timeout_ms must be positive: {self.statement_timeout_ms}")
+
+        if self.visibility_timeout_s <= 0:
+            raise ValueError(f"visibility_timeout_s must be positive: {self.visibility_timeout_s}")
+
+        if self.pool_timeout_s <= 0:
+            raise ValueError(f"pool_timeout_s must be positive: {self.pool_timeout_s}")
+
+        if self.watchdog_interval_s <= 0:
+            raise ValueError(f"watchdog_interval_s must be positive: {self.watchdog_interval_s}")
+
+        # Statement timeout must be less than visibility timeout
+        if self.statement_timeout_s >= self.visibility_timeout_s:
+            raise ValueError(
+                f"statement_timeout ({self.statement_timeout_s}s) must be less than "
+                f"visibility_timeout ({self.visibility_timeout_s}s)"
+            )
+
+
+def validate_timeouts(
+    statement_timeout_ms: int = DEFAULT_STATEMENT_TIMEOUT_MS,
+    visibility_timeout_s: int = DEFAULT_VISIBILITY_TIMEOUT_S,
+) -> None:
+    """Validate statement and visibility timeouts.
+
+    Args:
+        statement_timeout_ms: PostgreSQL statement timeout in milliseconds
+        visibility_timeout_s: PGMQ visibility timeout in seconds
+
+    Raises:
+        ValueError: If statement_timeout >= visibility_timeout
+    """
+    config = TimeoutConfig(
+        statement_timeout_ms=statement_timeout_ms,
+        visibility_timeout_s=visibility_timeout_s,
+    )
+    config.validate()
+
+
+def create_pool_with_timeout(
+    conninfo: str,
+    min_size: int = 4,
+    max_size: int | None = None,
+    timeout: float = DEFAULT_POOL_TIMEOUT_S,
+    **kwargs: Any,
+) -> ConnectionPool[Any]:
+    """Create a connection pool with proper timeout configuration.
+
+    Args:
+        conninfo: PostgreSQL connection string
+        min_size: Minimum pool size (should be >= worker concurrency)
+        max_size: Maximum pool size (defaults to min_size * 2)
+        timeout: Pool timeout in seconds (fail-fast on exhaustion)
+        **kwargs: Additional arguments passed to ConnectionPool
+
+    Returns:
+        Configured ConnectionPool instance
+
+    Example:
+        pool = create_pool_with_timeout(
+            conninfo=DATABASE_URL,
+            min_size=4,
+            timeout=30.0,
+        )
+    """
+    if max_size is None:
+        max_size = min_size * 2
+
+    return ConnectionPool(
+        conninfo=conninfo,
+        min_size=min_size,
+        max_size=max_size,
+        timeout=timeout,
+        **kwargs,
+    )
+
+
+def is_timeout_error(error: Exception) -> bool:
+    """Check if an exception is a timeout-related error.
+
+    Args:
+        error: The exception to check
+
+    Returns:
+        True if the error is timeout-related (QueryCanceled or PoolTimeout)
+    """
+    return isinstance(error, psycopg_errors.QueryCanceled | PoolTimeout)
+
+
+def is_query_cancelled(error: Exception) -> bool:
+    """Check if an exception is a QueryCanceled error.
+
+    This indicates the PostgreSQL statement timeout was exceeded.
+
+    Args:
+        error: The exception to check
+
+    Returns:
+        True if the error is QueryCanceled
+    """
+    return isinstance(error, psycopg_errors.QueryCanceled)
+
+
+def is_pool_timeout(error: Exception) -> bool:
+    """Check if an exception is a PoolTimeout error.
+
+    This indicates connection pool exhaustion.
+
+    Args:
+        error: The exception to check
+
+    Returns:
+        True if the error is PoolTimeout
+    """
+    return isinstance(error, PoolTimeout)

--- a/tests/unit/sync/test_sync_process_router.py
+++ b/tests/unit/sync/test_sync_process_router.py
@@ -367,7 +367,8 @@ class TestSyncProcessReplyRouterHealthTracking:
             managers={},
             reply_queue="orders__replies",
             domain="orders",
-            visibility_timeout=1,
+            visibility_timeout=30,
+            statement_timeout=1000,  # 1s statement timeout
         )
 
         # Add an old in-flight task

--- a/tests/unit/sync/test_sync_worker.py
+++ b/tests/unit/sync/test_sync_worker.py
@@ -562,7 +562,12 @@ class TestSyncWorkerHealthTracking:
     def test_check_stuck_threads(self) -> None:
         """Should detect stuck threads based on timeout."""
         mock_pool = MagicMock()
-        worker = SyncWorker(mock_pool, domain="payments", visibility_timeout=1)
+        worker = SyncWorker(
+            mock_pool,
+            domain="payments",
+            visibility_timeout=30,
+            statement_timeout=1000,  # 1s statement timeout
+        )
 
         # Add an old in-flight task
         mock_future = MagicMock()

--- a/tests/unit/sync/test_timeouts.py
+++ b/tests/unit/sync/test_timeouts.py
@@ -1,0 +1,245 @@
+"""Unit tests for commandbus.sync.timeouts module."""
+
+import pytest
+from psycopg import errors as psycopg_errors
+from psycopg_pool import PoolTimeout
+
+from commandbus.sync.timeouts import (
+    DEFAULT_POOL_TIMEOUT_S,
+    DEFAULT_STATEMENT_TIMEOUT_MS,
+    DEFAULT_VISIBILITY_TIMEOUT_S,
+    DEFAULT_WATCHDOG_INTERVAL_S,
+    STUCK_THREAD_BUFFER_S,
+    TimeoutConfig,
+    is_pool_timeout,
+    is_query_cancelled,
+    is_timeout_error,
+    validate_timeouts,
+)
+
+
+class TestTimeoutDefaults:
+    """Tests for timeout default values."""
+
+    def test_default_statement_timeout(self) -> None:
+        """Should have default statement timeout of 25s."""
+        assert DEFAULT_STATEMENT_TIMEOUT_MS == 25000
+
+    def test_default_visibility_timeout(self) -> None:
+        """Should have default visibility timeout of 30s."""
+        assert DEFAULT_VISIBILITY_TIMEOUT_S == 30
+
+    def test_default_pool_timeout(self) -> None:
+        """Should have default pool timeout of 30s."""
+        assert DEFAULT_POOL_TIMEOUT_S == 30.0
+
+    def test_default_watchdog_interval(self) -> None:
+        """Should have default watchdog interval of 10s."""
+        assert DEFAULT_WATCHDOG_INTERVAL_S == 10.0
+
+    def test_stuck_thread_buffer(self) -> None:
+        """Should have stuck thread buffer of 5s."""
+        assert STUCK_THREAD_BUFFER_S == 5.0
+
+
+class TestTimeoutConfig:
+    """Tests for TimeoutConfig dataclass."""
+
+    def test_default_values(self) -> None:
+        """Should use default values when not specified."""
+        config = TimeoutConfig()
+
+        assert config.statement_timeout_ms == DEFAULT_STATEMENT_TIMEOUT_MS
+        assert config.visibility_timeout_s == DEFAULT_VISIBILITY_TIMEOUT_S
+        assert config.pool_timeout_s == DEFAULT_POOL_TIMEOUT_S
+        assert config.watchdog_interval_s == DEFAULT_WATCHDOG_INTERVAL_S
+
+    def test_custom_values(self) -> None:
+        """Should accept custom values."""
+        config = TimeoutConfig(
+            statement_timeout_ms=10000,
+            visibility_timeout_s=20,
+            pool_timeout_s=15.0,
+            watchdog_interval_s=5.0,
+        )
+
+        assert config.statement_timeout_ms == 10000
+        assert config.visibility_timeout_s == 20
+        assert config.pool_timeout_s == 15.0
+        assert config.watchdog_interval_s == 5.0
+
+    def test_statement_timeout_seconds_property(self) -> None:
+        """Should convert statement timeout to seconds."""
+        config = TimeoutConfig(statement_timeout_ms=25000)
+
+        assert config.statement_timeout_s == 25.0
+
+    def test_stuck_threshold_property(self) -> None:
+        """Should calculate stuck threshold."""
+        config = TimeoutConfig(visibility_timeout_s=30)
+
+        assert config.stuck_threshold_s == 35.0
+
+    def test_immutable(self) -> None:
+        """Should be immutable (frozen dataclass)."""
+        config = TimeoutConfig()
+
+        with pytest.raises(AttributeError):
+            config.statement_timeout_ms = 10000  # type: ignore[misc]
+
+
+class TestTimeoutConfigValidation:
+    """Tests for TimeoutConfig.validate method."""
+
+    def test_validate_default_config(self) -> None:
+        """Should pass with default values."""
+        config = TimeoutConfig()
+        config.validate()  # Should not raise
+
+    def test_validate_statement_less_than_visibility(self) -> None:
+        """Should pass when statement < visibility."""
+        config = TimeoutConfig(
+            statement_timeout_ms=10000,  # 10s
+            visibility_timeout_s=20,  # 20s
+        )
+        config.validate()  # Should not raise
+
+    def test_validate_statement_equal_visibility_fails(self) -> None:
+        """Should fail when statement == visibility."""
+        config = TimeoutConfig(
+            statement_timeout_ms=30000,  # 30s
+            visibility_timeout_s=30,  # 30s
+        )
+
+        with pytest.raises(ValueError, match="must be less than"):
+            config.validate()
+
+    def test_validate_statement_greater_visibility_fails(self) -> None:
+        """Should fail when statement > visibility."""
+        config = TimeoutConfig(
+            statement_timeout_ms=40000,  # 40s
+            visibility_timeout_s=30,  # 30s
+        )
+
+        with pytest.raises(ValueError, match="must be less than"):
+            config.validate()
+
+    def test_validate_negative_statement_timeout_fails(self) -> None:
+        """Should fail with negative statement timeout."""
+        config = TimeoutConfig(statement_timeout_ms=-1)
+
+        with pytest.raises(ValueError, match="statement_timeout_ms must be positive"):
+            config.validate()
+
+    def test_validate_zero_statement_timeout_fails(self) -> None:
+        """Should fail with zero statement timeout."""
+        config = TimeoutConfig(statement_timeout_ms=0)
+
+        with pytest.raises(ValueError, match="statement_timeout_ms must be positive"):
+            config.validate()
+
+    def test_validate_negative_visibility_timeout_fails(self) -> None:
+        """Should fail with negative visibility timeout."""
+        config = TimeoutConfig(visibility_timeout_s=-1)
+
+        with pytest.raises(ValueError, match="visibility_timeout_s must be positive"):
+            config.validate()
+
+    def test_validate_negative_pool_timeout_fails(self) -> None:
+        """Should fail with negative pool timeout."""
+        config = TimeoutConfig(pool_timeout_s=-1.0)
+
+        with pytest.raises(ValueError, match="pool_timeout_s must be positive"):
+            config.validate()
+
+    def test_validate_negative_watchdog_interval_fails(self) -> None:
+        """Should fail with negative watchdog interval."""
+        config = TimeoutConfig(watchdog_interval_s=-1.0)
+
+        with pytest.raises(ValueError, match="watchdog_interval_s must be positive"):
+            config.validate()
+
+
+class TestValidateTimeouts:
+    """Tests for validate_timeouts function."""
+
+    def test_validate_defaults(self) -> None:
+        """Should pass with default values."""
+        validate_timeouts()  # Should not raise
+
+    def test_validate_valid_timeouts(self) -> None:
+        """Should pass with valid timeouts."""
+        validate_timeouts(
+            statement_timeout_ms=10000,
+            visibility_timeout_s=20,
+        )  # Should not raise
+
+    def test_validate_invalid_timeouts(self) -> None:
+        """Should raise with invalid timeouts."""
+        with pytest.raises(ValueError):
+            validate_timeouts(
+                statement_timeout_ms=40000,  # 40s > 30s
+                visibility_timeout_s=30,
+            )
+
+
+class TestIsTimeoutError:
+    """Tests for is_timeout_error function."""
+
+    def test_query_cancelled_is_timeout(self) -> None:
+        """Should return True for QueryCanceled."""
+        error = psycopg_errors.QueryCanceled()
+        assert is_timeout_error(error) is True
+
+    def test_pool_timeout_is_timeout(self) -> None:
+        """Should return True for PoolTimeout."""
+        error = PoolTimeout()
+        assert is_timeout_error(error) is True
+
+    def test_generic_exception_not_timeout(self) -> None:
+        """Should return False for generic exceptions."""
+        error = Exception("test")
+        assert is_timeout_error(error) is False
+
+    def test_value_error_not_timeout(self) -> None:
+        """Should return False for ValueError."""
+        error = ValueError("test")
+        assert is_timeout_error(error) is False
+
+
+class TestIsQueryCancelled:
+    """Tests for is_query_cancelled function."""
+
+    def test_query_cancelled(self) -> None:
+        """Should return True for QueryCanceled."""
+        error = psycopg_errors.QueryCanceled()
+        assert is_query_cancelled(error) is True
+
+    def test_pool_timeout_not_query_cancelled(self) -> None:
+        """Should return False for PoolTimeout."""
+        error = PoolTimeout()
+        assert is_query_cancelled(error) is False
+
+    def test_generic_exception_not_query_cancelled(self) -> None:
+        """Should return False for generic exceptions."""
+        error = Exception("test")
+        assert is_query_cancelled(error) is False
+
+
+class TestIsPoolTimeout:
+    """Tests for is_pool_timeout function."""
+
+    def test_pool_timeout(self) -> None:
+        """Should return True for PoolTimeout."""
+        error = PoolTimeout()
+        assert is_pool_timeout(error) is True
+
+    def test_query_cancelled_not_pool_timeout(self) -> None:
+        """Should return False for QueryCanceled."""
+        error = psycopg_errors.QueryCanceled()
+        assert is_pool_timeout(error) is False
+
+    def test_generic_exception_not_pool_timeout(self) -> None:
+        """Should return False for generic exceptions."""
+        error = Exception("test")
+        assert is_pool_timeout(error) is False


### PR DESCRIPTION
## Summary

- Add `timeouts.py` module with `TimeoutConfig` dataclass for timeout configuration
- Add `validate_timeouts()` function that enforces `statement_timeout < visibility_timeout`
- Add helper functions: `is_timeout_error()`, `is_query_cancelled()`, `is_pool_timeout()`
- Add `create_pool_with_timeout()` factory function
- Update `SyncWorker` to:
  - Validate timeouts on initialization
  - Catch `PoolTimeout` in `_poll_and_dispatch()` and record pool exhaustion
  - Catch `QueryCanceled` and `PoolTimeout` in `_process_command()` as transient errors
- Update `SyncProcessReplyRouter` to:
  - Validate timeouts on initialization
  - Catch `PoolTimeout` in `_poll_and_dispatch()` and record pool exhaustion
  - Catch `QueryCanceled` and `PoolTimeout` in `_process_reply()`
- Export timeout utilities from sync module

**Timeout Hierarchy:**
```
Layer 1: statement_timeout (25s) - kills slow queries on server
Layer 2: pool_timeout (30s) - fail-fast on pool exhaustion
Layer 3: visibility_timeout (30s) - message reappears if not deleted
Layer 4: stuck_threshold (35s) - detect stuck threads
Layer 5: watchdog (configurable) - monitor and recover workers
```

## Test plan

- [ ] Unit tests for TimeoutConfig with default and custom values
- [ ] Unit tests for validation (statement < visibility, positive values)
- [ ] Unit tests for is_timeout_error, is_query_cancelled, is_pool_timeout helpers
- [ ] Updated stuck thread tests to use valid timeout combinations
- [ ] Integration tests verify workers validate timeouts on init

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)