### PR TITLE
feat: Migrate E2E app to native sync components (S087)

### DIFF
--- a/tests/e2e/app/handlers/__init__.py
+++ b/tests/e2e/app/handlers/__init__.py
@@ -1,5 +1,7 @@
 """E2E Application Handlers and Registry setup."""
 
+from typing import Any
+
 from psycopg_pool import AsyncConnectionPool
 
 from commandbus import HandlerRegistry
@@ -29,4 +31,40 @@ def create_registry(pool: AsyncConnectionPool) -> HandlerRegistry:
     return registry
 
 
-__all__ = ["NoOpHandlers", "ReportingHandlers", "TestCommandHandlers", "create_registry"]
+def create_sync_registry(pool: Any) -> HandlerRegistry:
+    """Create handler registry with sync handlers for native SyncWorker.
+
+    This wraps async handlers with sync adapters using asyncio.run(),
+    allowing the same handler implementations to work with both async
+    and sync workers.
+
+    Args:
+        pool: Database connection pool (can be async or sync, handlers
+              will use it according to their implementation)
+
+    Returns:
+        HandlerRegistry with sync handlers registered
+    """
+    # Create handler instances with dependencies
+    # Note: handlers still use async pool internally - each sync dispatch
+    # runs the async handler in its own event loop via asyncio.run()
+    test_handlers = TestCommandHandlers(pool)
+    no_op_handlers = NoOpHandlers(pool)
+    reporting_handlers = ReportingHandlers(pool)
+
+    # Register as sync handlers (wraps async handlers)
+    registry = HandlerRegistry()
+    registry.register_instance_as_sync(test_handlers)
+    registry.register_instance_as_sync(no_op_handlers)
+    registry.register_instance_as_sync(reporting_handlers)
+
+    return registry
+
+
+__all__ = [
+    "NoOpHandlers",
+    "ReportingHandlers",
+    "TestCommandHandlers",
+    "create_registry",
+    "create_sync_registry",
+]

--- a/tests/integration/test_sync_mode.py
+++ b/tests/integration/test_sync_mode.py
@@ -1,58 +1,78 @@
-"""Integration smoke test for sync runtime components (S074)."""
+"""Integration smoke test for sync runtime components (S074/S087)."""
 
 from __future__ import annotations
 
 import asyncio
+import threading
+from typing import Any
 from uuid import uuid4
 
 import pytest
+from psycopg_pool import ConnectionPool
 
-from commandbus import CommandBus
+from commandbus import Command, CommandBus
 from commandbus.handler import HandlerRegistry
 from commandbus.models import CommandStatus, HandlerContext
-from commandbus.sync import SyncCommandBus, SyncRuntime, SyncWorker
-from commandbus.worker import Worker
+from commandbus.sync import SyncCommandBus, SyncWorker
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-@pytest.mark.skip(
-    reason="Wrapper-based SyncCommandBus replaced by native sync - to be updated in S087"
-)
-async def test_sync_runtime_round_trip(pool, cleanup_payments_domain) -> None:
-    """Send and process a command entirely through sync wrappers."""
-    registry = HandlerRegistry()
-    handled: list[str] = []
+async def test_native_sync_round_trip(pool, cleanup_payments_domain) -> None:
+    """Send and process a command using native sync components (S087)."""
+    # Get connection info from async pool to create sync pool
+    conninfo = pool.conninfo
 
-    @registry.handler("payments", "SyncRuntimeCommand")
-    async def handle_sync_command(_command, _ctx: HandlerContext) -> dict[str, str]:
-        handled.append("ok")
-        return {"status": "processed"}
-
-    base_worker = Worker(
-        pool,
-        domain="payments",
-        registry=registry,
-        visibility_timeout=5,
+    # Create sync pool for native sync components
+    sync_pool: ConnectionPool[Any] = ConnectionPool(
+        conninfo=conninfo,
+        min_size=2,
+        max_size=4,
+        open=True,
     )
-    runtime = SyncRuntime()
-    sync_worker = SyncWorker(worker=base_worker, runtime=runtime, thread_pool_size=2)
-    sync_bus = SyncCommandBus(bus=CommandBus(pool), runtime=runtime)
 
     try:
-        sync_worker.run(block=False, concurrency=1, poll_interval=0.1, use_notify=False)
+        # Create registry with sync handlers
+        registry = HandlerRegistry()
+        handled: list[str] = []
+
+        @registry.sync_handler("payments", "SyncNativeCommand")
+        def handle_sync_command(_command: Command, _ctx: HandlerContext) -> dict[str, str]:
+            handled.append("ok")
+            return {"status": "processed"}
+
+        # Create native sync worker
+        sync_worker = SyncWorker(
+            pool=sync_pool,
+            domain="payments",
+            registry=registry,
+            visibility_timeout=30,
+            statement_timeout=25000,
+        )
+
+        # Create native sync command bus
+        sync_bus = SyncCommandBus(sync_pool)
+
+        # Run worker in background thread
+        worker_thread = threading.Thread(
+            target=sync_worker.run,
+            kwargs={"concurrency": 1, "poll_interval": 0.1},
+            daemon=True,
+        )
+        worker_thread.start()
         await asyncio.sleep(0.25)  # allow worker thread to start polling
 
+        # Send command using sync bus (from main thread)
         command_id = uuid4()
         await asyncio.to_thread(
             sync_bus.send,
             domain="payments",
-            command_type="SyncRuntimeCommand",
+            command_type="SyncNativeCommand",
             command_id=command_id,
-            data={"payload": "sync-test"},
+            data={"payload": "sync-native-test"},
         )
-        await asyncio.sleep(0.25)
 
+        # Wait for command to complete
         command_bus = CommandBus(pool)
         for _ in range(60):
             metadata = await command_bus.get_command("payments", command_id)
@@ -60,10 +80,10 @@ async def test_sync_runtime_round_trip(pool, cleanup_payments_domain) -> None:
                 break
             await asyncio.sleep(0.25)
         else:  # pragma: no cover - defensive guard for CI flake
-            raise AssertionError("Command did not complete in sync mode")
+            raise AssertionError("Command did not complete in native sync mode")
 
         assert handled == ["ok"]
     finally:
         sync_worker.stop()
-        sync_worker.shutdown()
-        runtime.shutdown()
+        worker_thread.join(timeout=5.0)
+        sync_pool.close()


### PR DESCRIPTION
## Summary
- Add `register_instance_as_sync()` to HandlerRegistry for wrapping async handlers as sync handlers
- Add `handle_reply_sync()` to BaseProcessManager for sync router compatibility
- Update E2E worker to use native SyncWorker, SyncProcessReplyRouter, and sync ConnectionPool
- Remove SyncRuntime usage and concurrency cap workaround from sync mode
- Update integration test and unit tests for native sync pattern

## Test plan
- [ ] Unit tests pass (833 tests)
- [ ] Integration tests pass (including new native sync round-trip test)
- [ ] Coverage meets 80% threshold
- [ ] Linter and type checker pass

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)